### PR TITLE
Migrate Medium blog posts

### DIFF
--- a/src/content/blog/absolutely-clean-paths.md
+++ b/src/content/blog/absolutely-clean-paths.md
@@ -1,0 +1,38 @@
+---
+title: "Absolute-ly Clean Paths"
+description: "A quick tip for cleaning up messy relative import paths in Node projects using eslint-import-resolver-alias."
+pubDate: 2020-01-28
+tags: ["javascript", "eslint", "node"]
+---
+
+If you've ever dealt with deeply nested relative imports in a Node project, you know the pain:
+
+```javascript
+import MyComponent from '../../../components/MyComponent';
+```
+
+These paths are fragile, hard to read, and a nightmare when you refactor your folder structure.
+
+## The fix
+
+The `eslint-import-resolver-alias` package offers a clean solution. Install it, then add the following to your `.eslintrc.json`:
+
+```json
+{
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["src", "server"]
+      }
+    }
+  }
+}
+```
+
+The `paths` array should reference your source directories. Once configured, those messy relative imports become clean absolute-style paths:
+
+```javascript
+import MyComponent from 'components/MyComponent';
+```
+
+Much better. Your imports are now readable, resilient to folder restructuring, and consistent across the project.

--- a/src/content/blog/svgs-in-react-apps.md
+++ b/src/content/blog/svgs-in-react-apps.md
@@ -1,0 +1,51 @@
+---
+title: "SVGs in React Apps"
+description: "Exploring different approaches to using SVGs in React applications — inline embedding vs image tags, and the trade-offs of each."
+pubDate: 2019-12-16
+tags: ["svg", "react", "javascript"]
+---
+
+I have been a fan of using SVGs as my go-to image format in web applications for a long time. They have some key advantages:
+
+- They are **code** and can be managed as such very easily using source control and are easily editable
+- **Flexibility** in scale and colouring
+- **Compact** file sizes
+- **SEO friendly** as XML files
+
+There are a couple of common approaches to using SVGs in React apps, each with their own trade-offs.
+
+## Inline SVGs
+
+Embedding SVG code directly in your markup gives you full CSS control:
+
+```html
+<div>
+  <svg height="210" width="400">
+    <path d="M150 0 L75 200 L225 200 Z" />
+  </svg>
+</div>
+```
+
+You can then style them with CSS, including changing colours:
+
+```css
+svg {
+  fill: green;
+}
+```
+
+This approach enables full CSS manipulation, which is great for icons and small graphics. However, it becomes impractical for larger projects — inlining complex, reused SVGs across many components inflates your bundle size unnecessarily.
+
+## Image Tags
+
+The alternative is treating SVGs like any other image:
+
+```html
+<img src="my.svg" />
+```
+
+This technique enables on-demand lazy loading while keeping SVGs out of your application bundle. The trade-off is that CSS-based colour modification is no longer available, though scaling still works perfectly.
+
+## Which to choose?
+
+For small, frequently reused icons that need colour changes — go inline. For larger, decorative graphics — use image tags and keep your bundle lean.


### PR DESCRIPTION
## Summary
- Migrates two blog posts from Medium to Astro content collections
- **SVGs in React Apps** (published Dec 16, 2019) — approaches to using SVGs in React
- **Absolute-ly Clean Paths** (published Jan 28, 2020) — cleaning up relative imports with eslint-import-resolver-alias
- Posts use their original Medium publication dates

## Test plan
- [ ] Blog listing shows all 3 posts in chronological order
- [ ] Individual post pages render correctly
- [ ] Build succeeds