### PR TITLE
feat: add Leather open-source blog series (13 draft posts)

### DIFF
--- a/src/content/blog/building-multi-protocol-collectibles.md
+++ b/src/content/blog/building-multi-protocol-collectibles.md
@@ -1,0 +1,70 @@
+---
+title: "Building a Multi-Protocol NFT Gallery for a Bitcoin Wallet"
+description: "Supporting Ordinal Inscriptions, SIP-9 NFTs, Bitcoin Stamps, and BNS Names in a single collectibles experience"
+pubDate: 2025-11-15
+tags: ["code"]
+draft: true
+---
+
+Bitcoin and Stacks have multiple, completely different standards for digital collectibles. Ordinal Inscriptions live on Bitcoin's base layer. SIP-9 NFTs are smart contract tokens on Stacks. Bitcoin Stamps use a different encoding method entirely. BNS Names are Stacks' naming system. Each has different APIs, different metadata formats, and different rendering requirements.
+
+We needed to build a gallery that treats them all as first-class citizens -- displaying images, audio, video, SVGs, and even 3D models -- while keeping the codebase maintainable. I picked up this work as part of the mobile app build-out, and it became one of the biggest feature areas I worked on.
+
+<!-- ADD: Your background with NFTs/collectibles in crypto. Had you worked with ordinals before? What was your mental model going in? -->
+
+## The Approach
+
+### Protocol-Specific Data Layers
+
+Rather than trying to normalize everything into one shape early, we kept each protocol's data layer separate. Each has its own service, its own query hooks, and its own type definitions. This meant adding Stamps support ([#1689](https://github.com/leather-io/mono/pull/1689)) didn't touch the Ordinals code, and integrating the Gamma API for richer SIP-9 metadata ([#1635](https://github.com/leather-io/mono/pull/1635)) didn't affect anything else.
+
+The key insight was that normalization should happen at the UI layer, not the data layer. Each protocol maps to a shared `CollectibleView` type that the gallery components consume.
+
+<!-- ADD: How did you arrive at this insight? Was there a version where you tried normalizing early and it got messy? -->
+
+### Multi-Source Data Merging
+
+For SIP-9 NFTs, we integrated two separate APIs -- Hiro and Gamma -- and merged their data to get the best coverage. The team already had the Hiro integration; I added the Gamma layer and the merge strategy. Gamma provides richer metadata (collection info, rarity), while Hiro has broader token coverage. The merge strategy prioritises Gamma data when available, falling back to Hiro.
+
+### Rich Media Handling
+
+Ordinal inscriptions can be anything -- images, audio, video, SVG, HTML, even 3D GLTF models. Each format needs different rendering:
+
+- **Images**: Standard `<Image>` with IPFS gateway resolution and fallbacks
+- **Audio**: Audio player with waveform display
+- **Video**: Video player with auto-generated thumbnail previews ([#1756](https://github.com/leather-io/mono/pull/1756)) -- the app plays the video briefly and captures a frame
+- **SVG**: Rendered inline with sandboxing
+- **3D Models**: GLTF viewer component
+
+### Video Thumbnails: A Fun Problem
+
+The video thumbnail generation ([#1756](https://github.com/leather-io/mono/pull/1756)) was a satisfying solve. Rather than requiring a separate thumbnail service, the approach uses client-side frame capture that plays the video momentarily and screenshots it. The entire solution was a single file change (+213/-111 lines). The PR has a [video demo](https://github.com/leather-io/mono/pull/1756) showing it in action.
+
+<!-- ADD: What was the alternative you considered? Server-side thumbnail generation? Why did client-side win? Any edge cases with different video formats? -->
+
+### Detail Pages Per Protocol
+
+We split collectible detail views by protocol ([#1642](https://github.com/leather-io/mono/pull/1642), [#1636](https://github.com/leather-io/mono/pull/1636)) because each protocol has different metadata worth displaying. An Ordinal inscription shows its inscription number, content type, and sat rarity. A SIP-9 NFT shows its contract, collection, and traits. Trying to force these into one detail page would have been a mess.
+
+## From Mobile to Extension
+
+After building this for mobile (Sep-Nov 2025), I extracted the shared logic into `packages/features` ([#1981](https://github.com/leather-io/mono/pull/1981)) and worked on bringing it to the browser extension ([#1837](https://github.com/leather-io/mono/pull/1837), [#2067](https://github.com/leather-io/mono/pull/2067)). Other team members contributed to the extension integration too -- the queries and API layers that powered all of this were already in place thanks to earlier work by the team. The `CollectibleView` abstraction meant the same data logic powered both platforms, with only the rendering differing.
+
+The "go live" moment was [#2067](https://github.com/leather-io/mono/pull/2067) -- shipping the new extension home tab with a Collectibles tab alongside Assets and Activity.
+
+## The Result
+
+The gallery handles four distinct blockchain protocols, multiple media formats, and two data sources, while the UI code stays clean because each protocol handles its own complexity behind a shared interface.
+
+## Key PRs
+
+| PR | What | Stats | Video? |
+|---|---|---|---|
+| [#1689](https://github.com/leather-io/mono/pull/1689) | Stamps service integration | +2,110/-1,133, 18 files | |
+| [#1635](https://github.com/leather-io/mono/pull/1635) | Gamma API for SIP-9 | +409/-315, 15 files | |
+| [#1636](https://github.com/leather-io/mono/pull/1636) | Collectibles UI overhaul | +537/-464, 30 files | |
+| [#1642](https://github.com/leather-io/mono/pull/1642) | Audio, video, SVG formats | +817/-95, 27 files | |
+| [#1756](https://github.com/leather-io/mono/pull/1756) | Video thumbnail generation | +213/-111, 1 file | YES |
+| [#1981](https://github.com/leather-io/mono/pull/1981) | Shared CollectibleView utilities | +973/-111, 33 files | |
+| [#1837](https://github.com/leather-io/mono/pull/1837) | Cross-platform activity + NFTs tab | +4,796/-1,678, 152 files | YES |
+| [#2067](https://github.com/leather-io/mono/pull/2067) | Go live: extension home tab | +284/-99, 19 files | |

--- a/src/content/blog/container-architecture-three-iterations.md
+++ b/src/content/blog/container-architecture-three-iterations.md
@@ -1,0 +1,59 @@
+---
+title: "Three Iterations to Get Container Architecture Right"
+description: "Why the third time was the charm for our browser extension layout system"
+pubDate: 2024-08-15
+tags: ["code"]
+draft: true
+---
+
+Browser extensions are a weird UI context. A small popup (400x600px), full browser tabs, and "action popups" triggered by dApps. The same components need to work across all three. I iterated on this three times over 8 months.
+
+## v1: Full Page Views (Dec 2023 - Mar 2024)
+
+[#4655](https://github.com/leather-io/extension/pull/4655) (+4,990/-5,113, 358 files). Open Dec 7, merged Mar 28 -- nearly 4 months. This PR replaced baseDrawer with Radix.Dialog, standardised viewport width, moved CSS from the app to the UI library, refactored navigation out of Dialog, and fixed 8 bugs along the way.
+
+The problem: containers were rigid. Every page used the same structure.
+
+```jsx
+<Container header="back" footer="actions" title="Send Bitcoin">
+  {content}
+</Container>
+```
+
+## v2: UI Library Integration (Jun 2024)
+
+[#5544](https://github.com/leather-io/extension/pull/5544) (+5,949/-5,068, 310 files). Revealed that containers were tightly coupled to the old component structure. We also tried a Context-based approach ([#5619](https://github.com/leather-io/extension/pull/5619)) which didn't pan out.
+
+## v3: "This Time It's Composable" (Aug 2024)
+
+[#5715](https://github.com/leather-io/extension/pull/5715) (+1,548/-1,650, 110 files). Open Jul 31, merged Aug 1 -- **one day** (vs 4 months for v1). Driven by a [team discussion](https://github.com/orgs/leather-io/discussions/87). Routes no longer configure the container -- pages own their own headers via composition.
+
+```jsx
+<Container>
+  <Container.Header>
+    <BackButton />
+    <Title>Send Bitcoin</Title>
+  </Container.Header>
+  <Container.Body>{content}</Container.Body>
+  <Container.Footer>
+    <ActionButtons />
+  </Container.Footer>
+</Container>
+```
+
+v1 took 4 months and 358 files. v3 took 1 day and 110 files. The code got smaller AND faster to ship.
+
+<!-- ADD: What triggered each iteration? Was v1's rigidity obvious immediately or did it emerge over months? What was the team discussion like? Was there any resistance to "doing it again"? The PR title is great -- was it intentional humour? -->
+
+### v3.5: Popup Differentiation (Aug 2024)
+
+[#5778](https://github.com/leather-io/extension/pull/5778) (+815/-860, 49 files). Differentiated between the popup context and the action popup context. Fixed responsiveness issues.
+
+## Related Work
+
+The routing and modal work was deeply intertwined with containers:
+
+- [#4325](https://github.com/leather-io/extension/pull/4325) - Routable modals with `ModalBackgroundWrapper` (HAS VIDEO)
+- [#4351](https://github.com/leather-io/extension/pull/4351) - "Stab at routing"
+- [#5579](https://github.com/leather-io/extension/pull/5579) - Integrate Dialog from monorepo
+- [#5816](https://github.com/leather-io/extension/pull/5816) - Rename Dialog as Sheet

--- a/src/content/blog/cross-platform-monorepo.md
+++ b/src/content/blog/cross-platform-monorepo.md
@@ -1,0 +1,79 @@
+---
+title: "Sharing Features Between React Native and a Browser Extension in a Monorepo"
+description: "My first monorepo, two rendering targets, one shared feature layer"
+pubDate: 2025-12-01
+tags: ["code"]
+draft: true
+---
+
+<!-- ADD: This was your first monorepo. What was your experience before? What did you expect? What surprised you? -->
+
+I joined Leather coming from <!-- ADD: your previous experience -->. This was my first monorepo, my first time with React Native and Expo, and my first open-source project. The repo (`leather-io/mono`) was set up by the team before I joined -- the structure, tooling decisions, and initial packages were already in place. My role was building features within that structure, and eventually contributing to the cross-platform sharing patterns.
+
+Both apps needed the same features -- collectibles gallery, transaction activity, token details -- but the implementations were largely separate. Features were being built twice. Bugs were being fixed twice.
+
+## The `packages/features` Pattern
+
+The team's solution was a shared `packages/features` directory containing platform-agnostic feature logic. The key constraint: **features can contain business logic, data mapping, and shared types, but not platform-specific rendering**.
+
+Each feature exports:
+- **Data hooks** - query wrappers, data transformation
+- **View types** - typed interfaces that each platform's UI consumes (e.g. `CollectibleView`, `ActivityView`)
+- **Constants and utilities** - shared formatting, mapping functions
+- **Tests** - unit tests for the data layer
+
+The platform apps then import these and wrap them with their own UI components.
+
+### The Activity Example
+
+The biggest single expression of this pattern was [#1837](https://github.com/leather-io/mono/pull/1837) -- 152 files, +4,796/-1,678 lines. This PR:
+
+- Added a third tab for NFTs in the extension
+- Replaced the old activity component with one from the shared portfolio package
+- Refactored `packages/features` to be platform-agnostic
+- Moved shared activity logic to `packages/features/activity`
+- Introduced `ActivityView` -- a pre-formatted, UI-ready view of on-chain activity that both platforms consume via React Query's `select`
+
+Before this PR, we had the concept of `OnChainActivity` in our lists. Afterwards, all source `Activity` gets transformed to `ActivityView` for standardised UI rendering across platforms.
+
+The PR has a [video demo](https://github.com/leather-io/mono/pull/1837) showing activity working on both mobile and extension simultaneously.
+
+<!-- ADD: How long did this PR take? Was it reviewed in one go or iterated? What was the hardest part? -->
+
+### The Collectibles Example
+
+I built the collectibles UI on mobile first (Sep-Nov 2025), then extracted the shared logic into `packages/features` ([#1981](https://github.com/leather-io/mono/pull/1981)), and worked on bringing it to the extension ([#2067](https://github.com/leather-io/mono/pull/2067)). The underlying query hooks and API services were built by other team members -- my contribution was the UI layer and the cross-platform extraction.
+
+The `CollectibleView` type became the contract between the data layer and each platform's renderer. Mobile renders it with React Native's `Image` and `FlatList`. The extension renders it with HTML `img` tags and CSS grid. Same data, different presentation.
+
+## Build System: Where The Pain Lives
+
+Sharing code across platforms in a monorepo sounds clean in theory. In practice, the build system is where everything breaks.
+
+- **EAS builds broke** ([#2018](https://github.com/leather-io/mono/pull/2018)) because the mobile build system (Expo Application Services) ran `postinstall` scripts that conflicted with non-mobile packages. The fix involved avoiding lifecycle hooks (`prepare`) and fixing lingui translation compilation.
+- **Lingui translations** needed to compile correctly for both platforms
+- **pnpm workspace hoisting** caused dependency resolution issues across packages
+
+As someone new to monorepos, these were the hardest problems. The architecture pattern itself was straightforward -- the tooling to make two different build pipelines work with shared packages was not.
+
+<!-- ADD: What specific monorepo gotcha caught you off guard? Any advice for someone setting up their first monorepo? -->
+
+## The Go-Live Moment
+
+After weeks of feature-flagged development, [#2067](https://github.com/leather-io/mono/pull/2067) went live with the new extension home tab layout. This was the payoff for the whole team: a feature that took months to build on mobile was adapted for the extension in a fraction of the time because the data layer was already shared.
+
+## What I Learned From My First Monorepo
+
+1. **The real cost isn't the architecture -- it's the build system.** Getting EAS, webpack, and pnpm to play nicely together consumed more time than the actual feature code.
+2. **Share data, not UI.** View types as the contract between shared logic and platform-specific rendering worked well. Trying to share React components across React Native and React DOM would have been a nightmare.
+3. **Build one platform first, extract second.** Building mobile first and then extracting shared code was much easier than trying to build the shared layer abstractly.
+
+## Key PRs
+
+| PR | What | Stats | Video? |
+|---|---|---|---|
+| [#1981](https://github.com/leather-io/mono/pull/1981) | Shared feature utilities foundation | +973/-111, 33 files | |
+| [#1837](https://github.com/leather-io/mono/pull/1837) | Activity refactor + extension NFTs | +4,796/-1,678, 152 files | YES |
+| [#2067](https://github.com/leather-io/mono/pull/2067) | Go live: new extension home | +284/-99, 19 files | |
+| [#2018](https://github.com/leather-io/mono/pull/2018) | Fix EAS mobile build | +1,039/-15, 14 files | |
+| [#1824](https://github.com/leather-io/mono/pull/1824) | Setup new Home component | +213/-100, 7 files | |

--- a/src/content/blog/cryptowatch-cockpit-portfolio-table.md
+++ b/src/content/blog/cryptowatch-cockpit-portfolio-table.md
@@ -1,0 +1,35 @@
+---
+title: "Building the Cryptowatch Cockpit Portfolio Table"
+description: "Creating a real-time portfolio management table and trading UI components for Kraken's Cryptowatch platform"
+pubDate: 2026-02-23
+tags: ["code"]
+draft: true
+---
+
+Cryptowatch's Cockpit was the main trading interface -- a dense, real-time dashboard where users managed their positions across multiple exchanges. Think Bloomberg Terminal aesthetics but for crypto: live charts, order books, trade history, and portfolio data all on one screen. I joined the frontend team working on this before moving to Coderunner, and was pulled back in for three months when the Cockpit needed attention.
+
+## The Portfolio Table
+
+The main piece I built was a portfolio management HTML data table for the new chart view. This sat in the bottom panel of the Cockpit alongside tabs for open orders, holdings, margin positions, order history, and trade history.
+
+The table needed to handle the realities of a trading interface: real-time price updates flowing in via the ticker bar, sortable columns, and the ability to filter by trading pair. Users could link their exchange API keys and see their actual positions, balances, and order status. Each row showed market, side, type, date, price, quantity, fill percentage, and current market price with a percentage-to-market comparison.
+
+This was a pure HTML data table rather than reaching for a heavy table library. For a trading UI, rendering performance matters -- when prices are updating constantly, you don't want a table library's abstraction layer adding overhead.
+
+## Trading UI Components
+
+Beyond the portfolio table, I contributed a few components that were used across the broader platform:
+
+**A cross-browser range slider for leverage selection.** Margin trading requires users to select their leverage multiplier, and the native HTML range input looks different on every browser. Building a custom one that was consistent across Chrome, Firefox, and Safari while handling the precise increments that leverage selection requires was a satisfying problem.
+
+**Shared component library contributions.** Cryptowatch was actively building out a library of custom components during this period. Working on both Cockpit and Coderunner meant I had a good view of what was needed across the platform, and components I built for one project often found a home in the shared library.
+
+## E2E Testing Prototype
+
+I also built a proof-of-concept for automated E2E testing using Cypress. Trading UIs are notoriously hard to test -- there's real-time data, WebSocket connections, exchange API integrations, and complex user flows like placing an order, seeing it appear in the open orders tab, then watching it fill. The Cypress prototype demonstrated how we could automate these flows, though ultimately the QA team wanted to build their own testing system.
+
+## Context
+
+This work happened during a period of rapid growth at Cryptowatch. The frontend team was scaling up, we were overhauling the main charts page, and building out the shared component library simultaneously. I started on the trading frontend, was referred by a colleague who was then promoted to lead the new frontend team. We split into squads, and I moved between the trading/Cockpit work and the Coderunner automations project as priorities demanded.
+
+Working on the Cockpit was a good counterpoint to Coderunner. Coderunner was a greenfield product where I owned the entire frontend. Cockpit was an established, complex application where my contributions needed to fit into existing patterns and work alongside other engineers' code. Both required different skills -- one rewarded architectural thinking, the other rewarded precision and attention to integration detail.

--- a/src/content/blog/cryptowatch-coderunner-trading-automation.md
+++ b/src/content/blog/cryptowatch-coderunner-trading-automation.md
@@ -1,0 +1,58 @@
+---
+title: "Building Coderunner: A Trading Automation Tool at Cryptowatch"
+description: "Taking over a prototype and shipping an MVP for custom Python trading scripts at Kraken's Cryptowatch"
+pubDate: 2026-02-23
+tags: ["code"]
+draft: true
+---
+
+At Cryptowatch (owned by Kraken), we had power users who wanted more than the standard order types exchanges offered. Things like "cancel all my orders on this pair" or trailing take-profit orders -- synthetic order types that didn't exist natively on most exchanges. Coderunner was the answer: let users write and schedule custom Python scripts that executed trades through the Cryptowatch trading API.
+
+A single developer had built an initial prototype using a "jailed" Python instance that could safely run custom code within the browser. When he left, I joined as the sole frontend engineer responsible for rearchitecting the UI and taking it to MVP.
+
+## The Team
+
+For eight months I worked directly with one backend engineer (managing the Python scripts via Django) and the automations product owner. We were part of the broader "Trading and Automations" squad, but Coderunner was my domain on the frontend. The key stakeholders beyond our immediate team were Artur (Cryptowatch's creator) and Jesse Powell (then CEO of Kraken), both of whom had a keen interest in the project.
+
+I was pulled off Coderunner for three months to work on the main Cockpit product. When I came back, we added a designer to the team -- someone I'd referred -- and that's when the UI really started to come together.
+
+## What We Were Solving
+
+The core problems were straightforward to describe but tricky to build well:
+
+- Give users a code editor to write or customise Python trading scripts
+- Let them save scripts with reusable parameters
+- Schedule scripts to run at intervals (essentially a crontab for trades)
+- Show execution logs so users could see what their scripts did
+
+The goal was a polished MVP, fast. I planned the frontend architecture around making it easy to iterate -- clean code, portable state, quick to update when requirements shifted.
+
+## Architecture Decisions
+
+The stack was standard Cryptowatch: React, TypeScript, and PostCSS. But I made a deliberate choice on state management. While the rest of Cryptowatch used Redux, I went with React's `useReducer` for Coderunner. This kept the feature more portable and self-contained -- important for a product that was still finding its shape.
+
+The architecture followed a container/component pattern with composition over inheritance. The main Coderunner container composed sub-containers for scripts and logs, managing its own state plus the log state. Scripts maintained their own state independently. Custom hooks handled data fetching and polling over REST (WebSocket wasn't available for our endpoints). Midway through the project, GraphQL started gaining traction at the company -- it would have been a good improvement as a gateway to the backend, but we didn't get there.
+
+## The Tricky Bits
+
+**Dynamic form generation** was the most interesting challenge. Each Python script had a schema defining its input fields. Simple fields like strings were straightforward, but domain-specific fields like `marketID` and `exchangeID` needed real UX thought.
+
+Instead of showing users a raw market ID input, we built a market search field. Once they selected a market, we fetched their available funds on that pair and displayed the balance in the UI. The `amount` field was a custom numeric input with the asset slug overlaid (e.g. "ETH"), increment/decrement arrows, and proper handling of each currency's decimal precision.
+
+We initially used JSON Forms for form generation, but the level of customisation we needed led to fighting the library more than using it. Early on I decided to write our own form field generation code. This turned out to be the right call -- it kept things consistent with the broader Cryptowatch design system and let us contribute components back to the shared UI library.
+
+**Simulated logs** were a small but satisfying UX touch. Most script executions completed almost instantly, which made the UI feel broken -- you'd click "Run" and nothing visibly happened before results appeared. I introduced simulated running logs that displayed briefly before transitioning to the real completed output. It gave users confidence that something had actually executed.
+
+## Code Quality
+
+AceEditor worked well as the embedded code editor. For testing, we used React Testing Library with Jest. I also prototyped a Cypress E2E testing setup as a side project, though the QA team preferred to build their own system. Error handling used React Error Boundaries reporting to Sentry, which was important given the variety of script errors users could trigger.
+
+## The Redesigns
+
+We went through three redesigns of the UI before landing on the final MVP. Requirements shifted, release dates came and went, and there were crossed wires between product, design, and engineering -- partly because we hadn't documented requirements formally enough. It caused some tension, but nothing unusual for a prototype-stage product. As the company grew and the design system matured, the final version was something we were genuinely proud of.
+
+## The Outcome
+
+We completed the final MVP just before layoffs hit in November 2022. The web version proved the concept worked, and the decision was made to implement it in Cryptowatch's desktop app rather than ship the web version. I never got to see it in production, which was disappointing. But the work wasn't wasted -- by following clean engineering practices throughout, the components and patterns I'd built for Coderunner were contributed back to the main Cryptowatch codebase and used across the platform.
+
+The biggest takeaway was about building for change. Three UI redesigns, shifting requirements, a three-month gap in the middle -- the architecture held up through all of it because we'd invested in portability (useReducer over Redux), composability (container/component pattern), and clean boundaries between concerns.

--- a/src/content/blog/design-system-migration.md
+++ b/src/content/blog/design-system-migration.md
@@ -1,0 +1,59 @@
+---
+title: "Migrating a Design System: Stacks UI to Panda CSS"
+description: "Incrementally removing a design system across 500+ files in a production crypto wallet"
+pubDate: 2023-11-15
+tags: ["code"]
+draft: true
+---
+
+The Leather extension was built with `@stacks/ui`. When the wallet rebranded from Hiro to Leather and expanded to Bitcoin, the Stacks-branded design system had to go. The migration to Panda CSS touched 500+ files.
+
+<!-- ADD: Why Panda CSS over Tailwind, vanilla-extract, or others? Who made the decision? Was the 6-part removal your idea or was it already planned when you started? What was the most tedious part? -->
+
+## Stacks UI Removal (6-part series, Oct-Nov 2023)
+
+The removal was split into reviewable chunks:
+
+- [#4504 - Parts 4+5](https://github.com/leather-io/extension/pull/4504) (+790/-685, 122 files)
+- [#4515 - Part 6 (final)](https://github.com/leather-io/extension/pull/4515) (+254/-1,753, 26 files) -- a satisfying net negative
+- [#4511 - Part 2](https://github.com/leather-io/extension/pull/4511) (+533/-531, 39 files)
+
+## Panda CSS Preset
+
+The replacement wasn't just swapping one library for another. We built a Panda CSS preset as a shareable package:
+
+- [mono#151](https://github.com/leather-io/mono/pull/151) (+503/-124, 18 files) - the preset itself
+- [#5429](https://github.com/leather-io/extension/pull/5429) (+759/-556, 11 files) - integrate into extension
+
+Design tokens as a package meant any app could `npm install` the design system.
+
+## UI Library Integration
+
+- [#5544](https://github.com/leather-io/extension/pull/5544) (+5,949/-5,068, 310 files)
+- [#5550](https://github.com/leather-io/extension/pull/5550) (+204/-991, 63 files) -- another net negative
+
+## Icons
+
+[#4543](https://github.com/leather-io/extension/pull/4543) (+280/-231, 83 files) -- fixed react-icons/fi console errors.
+
+## The Borders Saga
+
+- [#5147](https://github.com/leather-io/extension/pull/5147) (Apr 2024) (+489/-425, 19 files)
+- [#6319](https://github.com/leather-io/extension/pull/6319) (Jul 2025) (+30/-36, 2 files) -- borders STILL breaking 15 months later
+
+The borders never stop breaking.
+
+## What Made This Work
+
+1. **Incremental migration in 6 parts** -- each chunk was reviewable, testable, and shippable
+2. **Net-negative PRs** -- #4515 removed 1,753 lines while adding 254. Less code = fewer bugs.
+3. **Zero-runtime CSS** -- Panda CSS generates at build time. No runtime overhead.
+4. **Design tokens as a package** -- shared across the monorepo
+
+## Monorepo Foundation
+
+I was assigned to early mono repo issues that laid groundwork for this migration:
+- [#5](https://github.com/leather-io/mono/issues/5) - Design tokens package
+- [#3](https://github.com/leather-io/mono/issues/3) - Migrate eslint-config
+- [#7](https://github.com/leather-io/mono/issues/7) - Setup workflow on monorepo
+- [#6](https://github.com/leather-io/mono/issues/6) - Investigate adding Nx

--- a/src/content/blog/expo-alternate-app-icons.md
+++ b/src/content/blog/expo-alternate-app-icons.md
@@ -1,0 +1,92 @@
+---
+title: "Personalizing Your App with Alternate Icons"
+description: "How we implemented 11 app icon options using expo-alternate-app-icons"
+pubDate: 2025-08-01
+tags: ["code"]
+draft: true
+---
+
+*This is Part 5 of the "Building a Crypto Wallet with Expo" series.*
+
+<!-- ADD: Was this your idea or a team/community request? What's the reaction been like from users? -->
+
+Sometimes the best features are the ones that bring users joy. Alternate app icons don't make your app more secure or more functional -- they just make users smile when they see _their_ icon on _their_ home screen.
+
+We ship 11 different app icon options in Leather, and users love it.
+
+## Why Alternate Icons?
+
+1. **Privacy** -- Some users prefer an icon that doesn't scream "I have crypto"
+2. **Personalization** -- Crypto users often identify strongly with specific aesthetics
+3. **Delight** -- In a sea of serious financial apps, a bit of personality goes a long way
+4. **Low effort, high reward** -- Once set up, adding new icons is just dropping in assets
+
+## The Setup
+
+```typescript
+// app.config.ts
+plugins: [
+  [
+    'expo-alternate-app-icons',
+    [
+      {
+        name: 'Icon1',
+        ios: './src/assets/icon-1.png',
+        android: {
+          foregroundImage: './src/assets/adaptive-icon-1.png',
+          backgroundColor: '#12100F',
+        },
+      },
+      // ... Icon2 through Icon11
+    ],
+  ],
+]
+```
+
+## The UI
+
+```typescript
+import { setAlternateAppIcon } from 'expo-alternate-app-icons';
+
+async function handleIconSelect(icon: AppIcon) {
+  try {
+    changeAppIconPreference(icon);
+    const nativeIconName = mapIconNameToNative(icon);
+    await setAlternateAppIcon(nativeIconName);
+  } catch (error) {
+    // Rollback preference if native change failed
+    changeAppIconPreference(appIconPreference);
+    Sentry.captureException(error);
+  }
+}
+```
+
+We store the user's preference separately from the actual icon state for instant UI updates and rollback capability.
+
+## The iOS Alert
+
+On iOS, changing the app icon shows a system alert: "You have changed the icon for Leather." This is an Apple requirement. To make it less jarring: show a preview before the user taps, use clear labeling, and don't show the picker on first launch.
+
+## Adding New Icons
+
+1. Create the assets (iOS 1024x1024, Android adaptive 432x432)
+2. Add the entry to `app.config.ts`
+3. Add to the `appIcons` array and labels
+4. Run `npx expo prebuild`
+5. Build and test
+
+## Series Conclusion
+
+Over these five posts, we've covered:
+
+1. **CI/CD**: Fingerprinting + EAS Workflows cut build times by 70%
+2. **Security**: expo-secure-store + expo-local-authentication protect seed phrases
+3. **Multi-chain**: Unified UI for Bitcoin and Stacks
+4. **Updates**: Safe OTA updates for a financial app
+5. **Personalization**: 11 app icons with expo-alternate-app-icons
+
+Expo and EAS have been transformative for our development velocity. We ship faster, test more thoroughly, and spend less time fighting native build issues.
+
+<!-- ADD: Wrap the series with a personal reflection. You started with zero React Native experience and built all of this. What would you tell someone about to start their first RN project? -->
+
+For a feature that took about a day to implement, the ROI has been excellent.

--- a/src/content/blog/expo-cicd-fingerprinting.md
+++ b/src/content/blog/expo-cicd-fingerprinting.md
@@ -1,0 +1,183 @@
+---
+title: "How We Cut Our Mobile CI Time by 70% with Expo and EAS"
+description: "Fingerprinting, EAS Workflows, and Maestro E2E tests for a production crypto wallet"
+pubDate: 2025-06-01
+tags: ["code"]
+draft: true
+---
+
+*This is Part 1 of the "Building a Crypto Wallet with Expo" series.*
+
+<!-- ADD: Frame this with your personal context. You'd never used React Native, Expo, or EAS before. Setting up CI for a mobile app was new territory. What was your experience with CI before this? How did you approach learning EAS? -->
+
+At [Leather](https://leather.io/), we're building a self-custody Bitcoin and Stacks wallet that millions of users trust with their digital assets. When you're handling people's money, quality isn't optional -- it's everything. That's why we invested heavily in our mobile CI/CD pipeline, and Expo's EAS platform has been transformative.
+
+We went from 20+ minute builds on every PR to under 6 minutes for most changes -- while _increasing_ our test coverage.
+
+## The Challenge: Security Meets Speed
+
+Cryptocurrency wallets face a unique challenge: we need the security rigor of a bank with the iteration speed of a startup. Our mobile app handles seed phrase generation, transaction signing, QR code scanning, biometric authentication, and push notifications. Every feature touches sensitive code paths. We can't ship bugs. But we also can't wait 20 minutes to find out if a PR is safe to merge.
+
+<!-- ADD: Relate this to the BTC Vegas launch pressure. When you were shipping multiple PRs a day in the lead-up to launch, slow CI would have been a blocker. Did you set up the CI before or after launch? -->
+
+## Our Expo Stack
+
+### Core Infrastructure
+
+- **Expo SDK 54** with expo-router for file-based navigation
+- **EAS Build** for cloud builds across 6 profiles (development, staging, production, preview, devClient, maestro)
+- **EAS Update** for over-the-air JavaScript updates
+- **EAS Workflows** for orchestrating our entire CI/CD pipeline
+
+### Native Features (31 Expo packages!)
+
+- `expo-secure-store` for encrypted credential storage
+- `expo-local-authentication` for Face ID/Touch ID
+- `expo-camera` for QR scanning
+- `expo-notifications` with Firebase Cloud Messaging
+- `expo-haptics` for tactile feedback
+- `expo-alternate-app-icons` (we have 11 app icons users can choose from!)
+
+## The Fingerprint Breakthrough
+
+The game-changer was understanding that **most PRs don't change native code**. We're primarily shipping JavaScript -- new features, bug fixes, UI tweaks. Why rebuild the entire native app for a copy change?
+
+Expo's `@expo/fingerprint` library generates a hash of everything that affects the native runtime: native dependencies, iOS and Android configuration, native modules and their versions, build settings.
+
+When the fingerprint matches a previous build, we know we can reuse that build and just update the JavaScript bundle.
+
+### Our Fingerprint Configuration
+
+```javascript
+// fingerprint.config.js
+module.exports = {
+  sourceSkips: [
+    'ExpoConfigRuntimeVersionIfString',
+    'ExpoConfigVersions',
+    'PackageJsonAndroidAndIosScriptsIfNotContainRun',
+    'PackageJsonScriptsAll',
+    'GitIgnore',
+  ],
+  ignorePaths: [
+    '**/GoogleService-Info*.plist',  // Environment-specific
+    '**/google-services*.json',
+    'src/assets/adaptive-icon.png',
+  ],
+};
+```
+
+## The Workflow
+
+Here's our EAS Workflow that runs on every PR:
+
+```yaml
+name: Maestro E2E Tests
+
+on:
+  pull_request:
+    branches: [dev]
+    paths:
+      - apps/mobile/**
+      - packages/**
+
+jobs:
+  # Step 1: Calculate fingerprint
+  fingerprint:
+    name: Fingerprint
+    type: fingerprint
+
+  # Step 2: Push JS bundle to EAS Update
+  run_eas_update:
+    name: EAS Update
+    type: update
+    params:
+      platform: all
+      channel: cicd
+
+  # Step 3: Check for existing builds
+  get_android_build:
+    name: Check Android Build
+    needs: [fingerprint]
+    type: get-build
+    params:
+      fingerprint_hash: ${{ needs.fingerprint.outputs.android_fingerprint_hash }}
+      profile: devClient
+      platform: android
+
+  # Step 4: Only build if no match found
+  build_android:
+    name: Build Android
+    needs: [get_android_build]
+    if: ${{ !needs.get_android_build.outputs.build_id }}
+    type: build
+    params:
+      platform: android
+      profile: devClient
+
+  # Step 5: Run E2E tests
+  maestro_android_cached:
+    name: Android Maestro (cached)
+    needs: [get_android_build, run_eas_update]
+    if: ${{ needs.get_android_build.outputs.build_id }}
+    type: maestro
+    params:
+      build_id: ${{ needs.get_android_build.outputs.build_id }}
+      flow_path: maestro/flows/full-suite-ci.yaml
+```
+
+For JavaScript-only changes, steps 3-4 take seconds instead of 15-20 minutes.
+
+## Maestro E2E Testing
+
+We use [Maestro](https://maestro.mobile.dev/) for E2E testing. Here's a sample:
+
+```yaml
+# shared/create-wallet.yaml
+appId: io.leather.mobilewallet
+---
+- tapOn:
+    id: 'homeCreateWalletCard'
+- tapOn:
+    id: 'createNewWalletSheetButton'
+- tapOn:
+    id: 'walletCreationTapToReveal'
+- tapOn:
+    id: 'walletCreationBackedUpButton'
+- tapOn:
+    text: 'Skip for now'
+- tapOn:
+    text: 'Continue'
+- assertVisible:
+    id: 'networkBadge'
+    timeout: 10000
+```
+
+Our full test suite covers wallet creation and restoration, settings navigation, send/receive flows, network switching, and wallet removal.
+
+<!-- ADD: Did you set up the Maestro tests? PR #726 was your Maestro E2E setup PR. What was the learning curve? Had you used E2E testing before? -->
+
+## The Results
+
+| Metric | Before | After |
+|---|---|---|
+| JS-only PR build time | ~20 min | ~6 min |
+| Native change build time | ~20 min | ~20 min |
+| Test coverage | Basic smoke | Full E2E suite |
+| Tests run per PR | Manual trigger | Automatic |
+
+**Most of our PRs are now in the "fast path"**. Native code changes are relatively rare compared to feature development and bug fixes.
+
+## Tips for Teams Adopting This Pattern
+
+1. **Start with fingerprinting** -- Even without the full workflow, understanding your fingerprint will show you how many builds you could skip.
+2. **Invest in testIDs early** -- Text-based assertions break with localization. We learned this the hard way when our CrowdIn integration broke all our tests.
+3. **Use development clients** -- The `devClient` profile gives you the speed of Expo Go with the flexibility of custom native code.
+4. **Organize shared flows** -- Maestro's `runFlow` command lets you compose tests.
+5. **Monitor your fingerprint hit rate** -- Track how often you're reusing builds vs. rebuilding.
+
+## Related PRs
+
+| PR | What | Stats |
+|---|---|---|
+| [#726](https://github.com/leather-io/mono/pull/726) | Maestro E2E test setup | +198/-1, 13 files |
+| [#2018](https://github.com/leather-io/mono/pull/2018) | Fix mobile CI build (EAS/pnpm/lingui conflicts) | +1,039/-15, 14 files |

--- a/src/content/blog/expo-multi-chain-architecture.md
+++ b/src/content/blog/expo-multi-chain-architecture.md
@@ -1,0 +1,92 @@
+---
+title: "Building a Multi-Chain Wallet UI with React Native"
+description: "Managing Bitcoin and Stacks in a unified interface with chain-specific balance, send, and receive flows"
+pubDate: 2025-07-01
+tags: ["code"]
+draft: true
+---
+
+*This is Part 3 of the "Building a Crypto Wallet with Expo" series.*
+
+<!-- ADD: This is where your crypto experience really matters. You understand WHY Bitcoin has UTXOs, WHY Stacks has locked balances. How did that domain knowledge shape the architecture? -->
+
+Leather started as a Stacks wallet, but our users wanted Bitcoin support too. The challenge: Bitcoin and Stacks are fundamentally different blockchains with different address formats, transaction models, and balance concepts. How do you build a UI that feels unified while respecting these differences?
+
+## The Account Model
+
+At the core is a unified account model:
+
+```typescript
+export type Account = {
+  id: string;                    // "fingerprint/accountIndex"
+  fingerprint: string;           // Wallet identifier
+  accountIndex: number;          // BIP44 account index
+  status: 'active' | 'hidden';
+  name: string;
+  icon: AccountIcon;
+};
+```
+
+**Accounts are chain-agnostic.** The same account can hold both Bitcoin and Stacks assets. We don't create separate "Bitcoin accounts" and "Stacks accounts."
+
+## Balance Architecture
+
+Bitcoin has a simple "available balance" (sum of UTXOs). Stacks has unlocked, locked, and total balances due to its stacking mechanism. The aggregate balance for the home screen combines both:
+
+```typescript
+export function useAccountTotalBalance({ fingerprint, accountIndex }: AccountId) {
+  const btc = useBtcAccountBalance(fingerprint, accountIndex);
+  const stx = useStxAccountBalance(fingerprint, accountIndex);
+
+  return useMemo(() => {
+    if (btc.state === 'loading' || stx.state === 'loading') {
+      return { state: 'loading' };
+    }
+    const totalQuote = addMoney(
+      btc.value?.quote.availableBalance,
+      stx.value?.quote.availableUnlockedBalance
+    );
+    return { state: 'success', value: { totalBalance: totalQuote } };
+  }, [btc, stx]);
+}
+```
+
+## Send Flow: Chain-Specific Forms
+
+While the entry point is unified ("Send" button), the forms differ by chain. Bitcoin sends require recipient address, amount, and fee rate selection (slow/medium/fast). Stacks sends require address, amount, and an optional memo field. Bitcoin users see fee rate selection because fees vary significantly. Stacks users see a memo field useful for exchange deposits.
+
+## Receive Flow: Multiple Address Types
+
+Bitcoin complicates things with multiple address types. We show both Native Segwit and Taproot addresses because some exchanges only support one type, users may want to consolidate UTXOs, and different address types have different fee characteristics.
+
+<!-- ADD: How do the branded BitcoinAddress types work in the multi-chain context? Does the type system prevent accidentally passing a Stacks address to a Bitcoin send function? -->
+
+## State Management
+
+```
+Redux: Account metadata (persisted)
+- Account names, icons, hidden/visible status, security preferences
+
+React Query: Blockchain data (cached, refetched)
+- Balances, transaction history, fee rates, exchange rates
+```
+
+Account metadata changes rarely and should persist. Blockchain data changes constantly and should be fresh.
+
+## Lessons Learned
+
+1. **Abstract at the right level** -- Accounts are chain-agnostic, but balances are chain-specific. Don't force a bad abstraction.
+2. **Show complexity only when needed** -- Bitcoin has multiple address types, but most users just want "an address."
+3. **Unify the entry points** -- One "Send" button, one "Receive" button. Chain selection happens after intent.
+4. **Design for the differences** -- Stacks has memos, Bitcoin has fee selection. Don't hide chain-specific features in the name of consistency.
+
+## Related PRs
+
+| PR | What | Stats |
+|---|---|---|
+| [#448](https://github.com/leather-io/mono/pull/448) | Tokens Widget (first balance display) | +933/-1,057 |
+| [#977](https://github.com/leather-io/mono/pull/977) | Activity UI integration | +755/-183, 59 files |
+| [#885](https://github.com/leather-io/mono/pull/885) | Branded address types | +1,002/-233, 47 files |
+| [#1465](https://github.com/leather-io/mono/pull/1465) | Token details on mobile | +1,340/-132, 48 files |
+| [#1130](https://github.com/leather-io/mono/pull/1130) | Loading states / prevent "$0" flash | +915/-518, 121 files |
+| [#6085](https://github.com/leather-io/extension/pull/6085) | UTXO consolidation (self-sends) | +6/-10 |

--- a/src/content/blog/expo-ota-updates.md
+++ b/src/content/blog/expo-ota-updates.md
@@ -1,0 +1,72 @@
+---
+title: "OTA Updates for Financial Apps"
+description: "Balancing speed with security using EAS Update for a production crypto wallet"
+pubDate: 2025-07-15
+tags: ["code"]
+draft: true
+---
+
+*This is Part 4 of the "Building a Crypto Wallet with Expo" series.*
+
+<!-- ADD: When did you first realise OTA updates were critical? Was there a specific incident where app store review would have been too slow? -->
+
+Over-the-air updates are a superpower for React Native apps. Ship a bug fix in minutes instead of days. No app store review, no waiting for users to update. But for a cryptocurrency wallet, this power comes with serious responsibility.
+
+If we ship a bad update, users could lose access to their funds. If an attacker compromised our update pipeline, they could steal seed phrases. This post covers how we use EAS Update responsibly.
+
+## The Risk Model
+
+1. **Bad code ships** -- A bug crashes the app or corrupts data
+2. **Supply chain attack** -- Malicious code injected into an update
+3. **Rollback failure** -- Users stuck on a broken version
+4. **Version skew** -- JS update incompatible with native code
+
+Each could result in users losing access to their cryptocurrency.
+
+## Configuration
+
+```typescript
+// app.config.ts
+export default {
+  updates: {
+    url: 'https://u.expo.dev/c03c1f22-be7b-4b76-aa1b-3ebf716bd2cc',
+  },
+  runtimeVersion: {
+    policy: 'fingerprint',
+  },
+};
+```
+
+The `fingerprint` runtime version policy ensures JavaScript updates only apply to compatible native builds.
+
+## Channel Strategy
+
+Updates flow through channels: **development** (internal testing) -> **staging** (QA) -> **production** (public). We never push directly to production.
+
+## Forced Update Mechanism
+
+For critical security fixes, we can force users to update via LaunchDarkly feature flags + version checking:
+
+```typescript
+export function useVersionCheck(): VersionCheckResult {
+  const minimumVersion = useMinimumAppVersion();  // From LaunchDarkly
+  const currentVersion = Application.nativeApplicationVersion;
+  return { needsUpdate: isVersionLessThan(currentVersion, minimumVersion) };
+}
+```
+
+We "fail open" on errors -- if we can't check the version, we let users continue. Blocking users due to a network error would be worse than the security risk.
+
+## What We Don't Do (Yet)
+
+**Staged rollouts** -- tricky for a wallet app where a "canary" user with $100k has more to lose than a test account. **Automatic updates** -- disabled because users should know when their wallet software changes, and automatic updates during a transaction could corrupt state.
+
+<!-- ADD: Has there been a real incident where you needed to ship a forced update? Any close calls? -->
+
+## Lessons Learned
+
+1. **Channel discipline is non-negotiable** -- Never push to production without staging
+2. **Fingerprint policy prevents disasters** -- Use `policy: 'fingerprint'` to prevent JS/native version skew
+3. **Fail open on version checks** -- A network error shouldn't lock users out of their funds
+4. **Feature flags enable instant response** -- Force updates without shipping new code
+5. **Manual approval for production** -- Automation is great for CI, dangerous for production deploys

--- a/src/content/blog/expo-secure-storage-biometrics.md
+++ b/src/content/blog/expo-secure-storage-biometrics.md
@@ -1,0 +1,115 @@
+---
+title: "Secure Storage & Biometrics in a Crypto Wallet"
+description: "How we protect seed phrases with expo-secure-store and expo-local-authentication"
+pubDate: 2025-06-15
+tags: ["code"]
+draft: true
+---
+
+*This is Part 2 of the "Building a Crypto Wallet with Expo" series.*
+
+<!-- ADD: As a seasoned crypto worker, you understand what happens when seed phrases leak better than most developers. How does that domain knowledge change how you approach the security implementation? -->
+
+In a cryptocurrency wallet, the seed phrase (mnemonic) is everything. It's the master key that controls all of a user's funds. If it leaks, their money is gone -- permanently and irreversibly. There's no "forgot password" flow, no customer support to call.
+
+## The Security Model
+
+Our security approach has three layers:
+
+1. **Encryption at rest** -- Seed phrases are stored in the device's secure enclave via `expo-secure-store`
+2. **Access control** -- Data is only accessible when the device is unlocked
+3. **Biometric gating** -- Optional Face ID/Touch ID requirement for sensitive operations
+
+## expo-secure-store: The Foundation
+
+```typescript
+export function getBasicSecureStoreConfig(): SecureStore.SecureStoreOptions {
+  return {
+    authenticationPrompt: 'Allow app to access secure storage',
+    keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY,
+  };
+}
+
+export function getBiometricsSecureStoreConfig(): SecureStore.SecureStoreOptions {
+  return {
+    ...getBasicSecureStoreConfig(),
+    requireAuthentication: true,  // Triggers biometric prompt on every access
+  };
+}
+```
+
+`WHEN_UNLOCKED_THIS_DEVICE_ONLY` means data is only accessible when the device is unlocked, never syncs to iCloud, and is deleted if the device is reset.
+
+## Versioned Mnemonic Storage
+
+How do you migrate encrypted data when your storage format changes?
+
+```typescript
+export function mnemonicStore(fingerprint: string): MnemonicStore {
+  return {
+    async getMnemonic(): Promise<MnemonicData | null> {
+      // Search newest version first, migrate if found in older version
+      const v2Data = await tryGetV2Mnemonic(fingerprint);
+      if (v2Data) return v2Data;
+
+      const v1Data = await tryGetV1Mnemonic(fingerprint);
+      if (v1Data) {
+        await this.setMnemonic(v1Data);  // Migrate to V2
+        await deleteV1Keys(fingerprint);
+        return v1Data;
+      }
+
+      return null;
+    },
+
+    async deleteMnemonic(): Promise<void> {
+      // Purge ALL version keys to ensure complete deletion
+      await Promise.all([
+        SecureStore.deleteItemAsync(getV1MnemonicKey(fingerprint)),
+        SecureStore.deleteItemAsync(getV1PassphraseKey(fingerprint)),
+        SecureStore.deleteItemAsync(getV2MnemonicKey(fingerprint)),
+        SecureStore.deleteItemAsync(getV2PassphraseKey(fingerprint)),
+      ]);
+    },
+  };
+}
+```
+
+## Biometric Authentication
+
+For sensitive operations, we require biometric authentication:
+
+```typescript
+export function useAuthentication(): UseAuthenticationResult {
+  async function callIfEnrolled<T>(callback: () => T): Promise<T | undefined> {
+    const securityLevel = await LocalAuthentication.getEnrolledLevelAsync();
+
+    if (securityLevel === LocalAuthentication.SecurityLevel.NONE) {
+      displayToast({ title: 'No device security configured', type: 'error' });
+      return undefined;
+    }
+
+    return callback();
+  }
+
+  return { authenticate, callIfEnrolled };
+}
+```
+
+The `callIfEnrolled` wrapper is important: without it, `authenticateAsync` **silently succeeds** on devices with no security configured -- which would defeat the entire purpose.
+
+<!-- ADD: Any war stories about testing secure storage? Did you ever have a bug where the biometric prompt didn't trigger, or where data was lost on migration? -->
+
+## Lessons Learned
+
+1. **Version your storage keys** -- You will need to migrate. Plan for it from day one.
+2. **Check enrollment before authenticating** -- `authenticateAsync` succeeds on devices with no security. Always check `getEnrolledLevelAsync` first.
+3. **Delete thoroughly** -- When a user removes a wallet, delete ALL possible key versions.
+4. **Respect user choice** -- Not everyone can use biometrics. Provide secure alternatives.
+5. **Test on real devices** -- Simulators don't have secure enclaves.
+
+## Related PRs
+
+| PR | What | Stats |
+|---|---|---|
+| [#4243](https://github.com/leather-io/extension/pull/4243) | Secret key redesign + mnemonic validation (extension) | +739/-436, 27 files |

--- a/src/content/blog/first-web-application-telco-monitoring.md
+++ b/src/content/blog/first-web-application-telco-monitoring.md
@@ -1,0 +1,70 @@
+---
+title: "My First Real Web Application: Building a Telco Monitoring Tool in 2012"
+description: "Before React, before frameworks, before crypto — I built an internal monitoring tool at The Now Factory using Java, jQuery, HighCharts, and the Google Visualisation API."
+pubDate: 2026-02-13
+tags: ["code"]
+draft: true
+---
+
+Before I was building Bitcoin wallets and trading automation tools, I was an Operations Engineer at The Now Factory in Sandyford, Dublin. The company made deep packet inspection probes — hardware that sat on mobile network operator infrastructure, analysing traffic patterns for telecoms companies worldwide.
+
+Around 2012, I built TNFMON DRE: an internal web application for monitoring the performance of these probes deployed at customer sites across the globe. It was a J2EE web application that I designed, built, and documented entirely on my own. I even wrote a 30-page user guide for it, which I recently dug out.
+
+Reading it back now is equal parts nostalgia and cringe. But it also reminds me that the instincts that drive my work today — building tools that replace manual processes, obsessing over data visualisation, making complex information accessible — were already there from the very beginning.
+
+## The Problem
+
+The Now Factory had SourceWorks probes deployed at telecoms operators (OPCOs) around the world. When engineers needed to analyse a probe's performance, the process was painful: they'd have to run a DCV (essentially a diagnostic report) on-site, which was time-consuming and required physical or remote access to the customer's infrastructure. When there was a critical issue, there simply wasn't time for this.
+
+Performance data and inventory information were being collected from these probes, but there was no centralised way to view, analyse, or trend. Engineers were manually pulling data into Excel spreadsheets and building reports by hand.
+
+## What I Built
+
+TNFMON DRE (the "DCV Replacement Engine") was a web application with three main modules:
+
+**Statistical Analysis Tool** — The core of the application. Engineers could select a customer site and a date range, and the system would generate interactive performance charts showing NIC speeds, packet drop rates, TDR production, GTP context lifecycle, protocol ratios, and IP fragmentation. All the metrics that mattered for understanding whether a probe was healthy or struggling.
+
+**Customer Inventory** — A centralised view of every probe's configuration: software versions, hardware specs, NIC card details, configuration file backups, scripts, and health check outputs. Before this, there was no single place at headquarters where you could look up what was running at a customer site.
+
+**Customer Matrix** — A global view across all customers, with searchable tables, dashboards, geographic coverage maps, revenue-by-customer charts, and a motion chart for trending data over time. This was aimed at giving management and sales a bird's-eye view of the entire deployment footprint.
+
+## The Tech Stack (Vintage 2012)
+
+This was before the framework wars. Before React, before Angular even. The stack was:
+
+- **Java Servlets and JSP** for the backend logic and dynamic page generation
+- **jQuery and jQuery UI** for all frontend interactivity — accordions, tabs, dialogs, AJAX data loading
+- **HighCharts** for all the performance charts — interactive, zoomable, exportable, with up to five Y-axes on a single chart
+- **Google Visualisation API** for the inventory tables, the customer dashboard, the geographic map, and a motion chart for trending
+- **HTML5 and CSS3** — I was pushing for modern standards at a time when IE still didn't support the canvas tag (HighCharts fell back to VML for IE)
+- **JSON** for data interchange between the server and the UI — the charts were driven by JSON strings generated on the server and parsed by JavaScript on the client
+
+No npm. No bundler. No package.json. Just JavaScript files referenced in HTML pages. And it worked.
+
+## The Parts I'm Still Proud Of
+
+**The charting.** Each chart was interactive with legend toggling, tooltips, zoom-by-drag, adjustable date ranges, print functionality, and image export. The "All in one" view plotted every metric on a single chart with multiple axes, and engineers could toggle individual series on and off to isolate what they cared about. There was also a one-click export that rendered all charts to a single image — replacing what had been a manual, hour-long report-building process.
+
+I wrote a custom HighCharts configuration specifically for this project. The key insight was that once you had a JSON data series for any metric, you could plot it on any chart against any other metric. That extensibility meant new charts could be added without touching the data layer. Compare that to Excel, where engineers were limited to two axes and had to rebuild the workbook every time.
+
+**The search and filtering.** The customer matrix used a jQuery DataTables plugin that let users filter across all fields with a keyword search. Type "H2" and you'd see every site running an H2 probe. Type a country name and you'd get all sites in that region. It sounds basic now, but in 2012, in an enterprise environment where the alternative was scrolling through spreadsheets, this was transformative.
+
+**The Google Visualisation API integration.** The motion chart for customer trends was genuinely ahead of its time — it let users animate data over time, switch between bubble, line, and bar views, and use logarithmic or linear scales. The geographic coverage map showed where probes were deployed worldwide, giving sales a visual tool they'd never had before.
+
+**Server-side validation with AJAX feedback.** Rather than letting users submit a form and wait for a full page reload to discover there was no data, the application checked server-side first and returned an AJAX response. Only valid host/date combinations with actual data would proceed to chart generation. Small thing, but it made the tool feel responsive rather than frustrating.
+
+## What I'd Do Differently Now
+
+Everything about the architecture, obviously. Java Servlets and JSP were the right tool in 2012 for someone working in a Java shop, but the entire frontend would be a React SPA today with an API backend. jQuery UI's accordion/tabs pattern is essentially what component composition gives you in any modern framework.
+
+The biggest thing I'd change is the lack of automated testing. The user guide includes a disclaimer that the application hadn't been through system test and likely had bugs. Today, I'd have unit tests, integration tests, and E2E coverage before writing any user documentation. My obsession with testing at every subsequent role — Cypress at Kraken, Cucumber at BAML, Vitest and Playwright at Trust Machines — probably has roots in shipping this project without a safety net.
+
+The data architecture was sound, though. Collecting everything into a central database and making charts a presentation layer over that data is essentially the same pattern I'd use today — just with a REST API and a frontend charting library like Recharts or D3 instead of HighCharts rendered from JSP-generated JSON.
+
+## Why This Project Matters
+
+I was 26 or 27 when I built this. I wasn't a frontend engineer yet — my title was Operations Engineer, and most of my day-to-day was supporting the probes themselves. I built TNFMON because I saw a problem (manual, slow diagnostics) and thought I could fix it with software.
+
+That impulse hasn't changed. At Kraken, I built Coderunner because institutional traders needed automation tools. At Trust Machines, I shipped a mobile wallet because Bitcoin users needed a better experience on their phones. The scale and the technology are completely different, but the pattern is the same: find the painful manual process, build the tool that replaces it, make the data accessible to the people who need it.
+
+Looking back at the user guide from 2012, with its jQuery plugins and its Java Servlets and its disclaimer about untested code, I can see the through-line to everything I've done since. The frameworks change. The instinct to build doesn't.

--- a/src/content/blog/human-readable-ethereum-transactions.md
+++ b/src/content/blog/human-readable-ethereum-transactions.md
@@ -1,0 +1,97 @@
+---
+title: "Making Ethereum Transactions Human-Readable"
+description: "Raw blockchain transactions are incomprehensible to most users. Here's how you decode them into something meaningful — and why it matters for crypto UX."
+pubDate: 2026-02-13
+tags: ["code"]
+draft: true
+---
+
+If you've ever looked at a raw Ethereum transaction, you know the problem. A wall of hexadecimal data, an ABI-encoded function call, token transfers buried in event logs, and no obvious indication of what actually happened. Did the user swap tokens? Stake ETH? Approve a spending limit? The blockchain knows, but it doesn't make it easy to find out.
+
+I worked on a system that solved this problem — decoding raw Ethereum transactions into plain-language summaries. The kind of thing where instead of seeing `0xa9059cbb000000000000000000000000...`, a user sees "Sent 1,500 USDC to 0xAbc...123."
+
+Here's how it works.
+
+## The Problem Space
+
+Ethereum transactions are opaque by design. A transaction's `input` field contains ABI-encoded data — the function signature and its parameters packed into a hex string. Unless you have the contract's ABI and know how to decode it, this data is meaningless.
+
+It gets worse with DeFi. A single Uniswap swap might involve multiple internal transactions, token approvals, liquidity pool interactions, and fee calculations — all compressed into one transaction hash. Token transfers don't even appear in the transaction's value field; they're emitted as ERC-20 `Transfer` events in the transaction receipt's logs.
+
+For wallets, explorers, and compliance tools, turning this raw data into something a human can understand is essential. Users need to know what happened. Compliance teams need audit trails. Portfolio trackers need accurate records.
+
+## Step 1: Simulate the Transaction
+
+The first insight is that you often can't fully understand a transaction just by looking at its encoded input data. You need to see its *effects* — what state changes did it actually produce?
+
+The approach: fork the blockchain state at the block where the transaction occurred, then replay the transaction in a local EVM. Tools like Ganache (or Hardhat's forking mode) can do this. You point a local EVM at an archive node, tell it to fork at a specific block number, and re-execute the transaction. This gives you the full execution trace: every internal call, every event log, every state change.
+
+Why simulate instead of just reading the receipt from the chain? Because simulation gives you access to intermediate states and internal transactions that aren't always visible in the standard transaction receipt. For complex DeFi interactions, this context is invaluable.
+
+## Step 2: Decode the Event Logs
+
+Once you have the transaction's event logs (either from simulation or the receipt), the real work begins. ERC-20 `Transfer` events follow a known signature:
+
+```
+Transfer(address indexed from, address indexed to, uint256 value)
+```
+
+The event topic `0xddf252ad1be2c89b69c2b068fc378daa952ba7f163c4a11628f55a4df523b3ef` is the keccak256 hash of this signature. When you see this topic in a log entry, you know a token transfer happened. The `from` and `to` addresses are in the indexed topics, and the `value` is in the log data.
+
+Similarly, ERC-721 NFT transfers use the same `Transfer` event signature but with `uint256 tokenId` instead of a fungible amount. ERC-1155 uses `TransferSingle` and `TransferBatch`. Each has a known topic hash you can match against.
+
+For non-standard events, you need the contract's ABI. Services like Etherscan's API or 4byte.directory can help match function selectors and event signatures to their human-readable forms.
+
+## Step 3: Resolve Token Metadata
+
+Knowing that a `Transfer` event moved `1500000000` units of a token at address `0x123...` isn't useful until you know the token's name, symbol, and decimals. A multicall (batching multiple `eth_call` requests) to the token contract resolves this:
+
+- `name()` → "USD Coin"
+- `symbol()` → "USDC"
+- `decimals()` → 6
+
+Now `1500000000` becomes `1,500 USDC`. Without this step, every amount is an incomprehensible large integer.
+
+Caching token metadata is essential — you'll see the same tokens repeatedly, and calling the contract every time is wasteful.
+
+## Step 4: Classify the Transaction
+
+This is where heuristics come in. Based on the decoded events and the transaction's input data, you can classify what type of operation occurred:
+
+**Swap** — The transaction interacted with a known DEX router (Uniswap, SushiSwap, 1inch, etc.) and the event logs show tokens going in and different tokens coming out. The function selector often confirms this (`swapExactTokensForTokens`, `exactInputSingle`, etc.).
+
+**Send/Receive** — A simple ERC-20 `Transfer` event where the `from` or `to` matches the user's address. No DEX interaction.
+
+**Approve** — An `Approval` event, granting a spender permission to move tokens on the user's behalf. The function selector is `approve(address,uint256)`.
+
+**Stake/Unstake** — Interaction with known staking contracts. Often identifiable by function names like `deposit`, `withdraw`, `stake`, `unstake` in the decoded input.
+
+**Add/Remove Liquidity** — Interaction with a DEX's liquidity pool. Events show tokens going into a pool contract and LP tokens being minted (or the reverse).
+
+**Contract Creation** — The transaction's `to` field is null, and the input data is the contract bytecode.
+
+**Mint** — A `Transfer` event where the `from` address is `0x0000...0000` (the zero address), indicating new tokens were created.
+
+Each classification maps to a human-readable template: "Swapped 1.5 ETH for 3,200 USDC on Uniswap" or "Approved USDC spending for Aave."
+
+## The Edge Cases
+
+Real-world transactions are messier than the clean categories above:
+
+**Multicalls** — Many DeFi protocols batch multiple operations into a single transaction. Uniswap V3's `multicall` can wrap a swap, a fee collection, and a liquidity adjustment into one tx. You need to decode each sub-call separately and present them as a sequence of operations.
+
+**Proxy contracts** — Many contracts use the proxy pattern, where the transaction goes to a proxy address but the logic lives in an implementation contract. The ABI you need for decoding belongs to the implementation, not the proxy. You have to detect this and resolve the implementation address.
+
+**Unknown contracts** — Not every contract has a verified ABI on Etherscan. For unknown contracts, you can still decode standard events (ERC-20 transfers, approvals) but the specific function call remains opaque. The best you can offer is "Interacted with contract 0x123..." plus whatever events you can decode.
+
+**Internal transactions** — When contract A calls contract B during execution, the token transfers in contract B's context don't appear as top-level events. You need the full execution trace from simulation to capture these.
+
+## Why This Matters
+
+Human-readable transactions are a UX problem, not just a technical one. Every crypto wallet, every block explorer, and every portfolio tracker needs this capability. When a user opens their transaction history and sees a list of hex strings, they lose trust. When they see "Swapped 0.5 ETH for 1,100 USDC on Uniswap — 3 hours ago," they understand their financial activity.
+
+For institutional users and compliance teams, the stakes are higher. Audit trails need to be comprehensible. Regulatory reporting requires clear descriptions of what happened, not raw calldata.
+
+The blockchain is a public ledger, but without decoding, it's a public ledger written in a language almost nobody speaks. Making transactions human-readable is how we translate.
+
+<!-- ADD: Can you share your perspective on working on this kind of infrastructure? How did it inform your thinking about crypto UX at Trust Machines / Leather? -->

--- a/src/content/blog/javascript-framework-analysis-fidelity.md
+++ b/src/content/blog/javascript-framework-analysis-fidelity.md
@@ -1,0 +1,85 @@
+---
+title: "Evaluating JavaScript Frameworks at Fidelity Investments in 2014"
+description: "A look back at evaluating Ember.js vs Backbone/Marionette for enterprise financial applications — and what it taught me about making technology decisions that stick."
+pubDate: 2026-02-13
+tags: ["code"]
+draft: true
+---
+
+In 2014, I was a UX Developer at Fidelity Investments in Dublin — one of the world's largest financial services firms, managing over $11 trillion in assets. My role involved leading frontend development for the UX team, including acting as technical lead for an offshore development team across the UK and India.
+
+One of the most impactful things I did during that year wasn't writing code. It was writing a document. A framework analysis that evaluated the JavaScript ecosystem and recommended a path forward for how the UX team should build complex browser-based applications.
+
+## The Problem
+
+By 2014, the jQuery-driven approach to building complex browser applications was showing its age. jQuery had been revolutionary — it made DOM manipulation bearable and smoothed over browser inconsistencies that would otherwise drive you mad. But it also made it very easy to end up with unmaintainable spaghetti code. As application complexity grew, the UX team needed a framework that could impose structure and make codebases sustainable across teams and time.
+
+The question was simple: which one?
+
+## The Contenders
+
+In 2014, the JavaScript framework landscape was dominated by three options: Angular.js, Ember.js, and Backbone.js (typically paired with Marionette).
+
+I ruled Angular out relatively early for the specific context of Fidelity's UX work. Angular was best suited for single-page, single-view applications. Our team built applications with multiple views and sub-views — complex, multi-screen workflows typical of financial software. Angular's architecture wasn't the right fit for that pattern.
+
+That left Ember.js and Backbone with Marionette — two fundamentally different philosophies of how to build frontend applications.
+
+## Opinionated vs Unopinionated
+
+This was the core tension, and it's a tension that still exists in frontend development today (think Next.js vs a custom Vite setup).
+
+**Backbone/Marionette** was lightweight and left all architectural decisions to the developer. File structure, state management, how views communicate — all of it was up to you. This offered maximum flexibility but demanded serious upfront planning. If multiple developers were working on the same project, you needed to establish and enforce conventions manually. Without discipline, codebases diverged.
+
+**Ember.js** was the opposite. It was heavily opinionated with strong rules around structure and architecture. It decided your file structure, your naming conventions, your routing patterns. The learning curve was steeper — it took real time before you could get a simple application up and running. But once you were productive, you were very productive. The conventions meant that any Ember developer could pick up any Ember project and immediately understand how it was organised.
+
+## The Evaluation Framework
+
+I structured the analysis around criteria from Addy Osmani (then a frontend engineer at Google, known for his TodoMVC project) and added a couple of my own:
+
+- What is the framework really capable of?
+- Has it been proved in production?
+- Is it mature?
+- Is it flexible or opinionated?
+- Does it have comprehensive documentation?
+- What's the total size, factoring in minification and gzip?
+- What's the community like?
+- How steep is the learning curve for someone new?
+- How quickly can applications be developed in a maintainable way across teams?
+
+Those last two were the ones I added, and they turned out to be the most important for our context. At Fidelity, we weren't building a side project. We were building financial software that would be maintained by rotating teams of developers, including offshore engineers I was training. The framework needed to make the right thing easy and the wrong thing hard.
+
+## What I Found
+
+Backbone had the larger community and more production deployments — Groupon, Foursquare, and others had been running Backbone apps for years. Its API was stable and well-documented. But it required writing a lot of boilerplate code. Every project needed its own architectural decisions, and those decisions had to be communicated and enforced across teams.
+
+Ember was younger — its 1.0 release had only landed in August 2013 after two years of development. The documentation was improving but patchy. The API had been intentionally unstable pre-1.0, which meant some examples and tutorials were already outdated. But the framework itself was remarkably productive once you got past the initial learning curve. Because it enforced conventions, distributed teams could work on the same codebase without the overhead of establishing shared standards from scratch.
+
+The size comparison was instructive too. Ember was considerably larger than Backbone, but that was misleading — Ember included everything you might need, while Backbone required Marionette plus additional plugins to offer comparable functionality, which closed the gap.
+
+## The Recommendation
+
+For the UX team at Fidelity, I recommended Ember.js. The reasoning came down to team dynamics and maintainability:
+
+We had developers across Dublin, the UK, and India. I was flying between offices to provide training and technical direction. In that context, a framework that imposed consistent structure was worth more than one that offered maximum flexibility. The steeper learning curve was a reasonable trade-off against the ongoing cost of architectural divergence across distributed teams.
+
+I also recommended Ember because of developer productivity. Once past the initial hump, Ember's conventions meant you could move fast without constantly making (and documenting) micro-decisions about how to organise code. For financial software where reliability matters, having the framework handle the boring structural decisions freed developers to focus on the business logic.
+
+## What Happened Next
+
+The framework analysis became a reference document for the UX team's technology choices. I went on to represent the engineering function during Enterprise Ireland's R&D accreditation process — a formal assessment of Fidelity's R&D activities in Ireland, where I acted as the technical expert throughout.
+
+After Fidelity, I moved to Kontainers (an ocean freight startup founded by a Fidelity alumnus), where I used Ember.js to take the product from inception to production. Then to Rocksteady, where I rescued a legacy Ember.js application and shipped the first stable release in 7 months. The framework evaluation at Fidelity kicked off a period where Ember became my primary tool — I became the person teams brought in when they needed Ember expertise.
+
+Eventually, React won the framework wars, and I made the transition around 2017 at Xapo. But the habits I built during the Ember years — strong conventions, opinionated architecture, consistent structure — carried over directly into how I approach React projects today.
+
+## The Retrospective
+
+Looking back from 2026, a few things stand out:
+
+**The analysis was right for the context.** Ember was the correct choice for distributed enterprise teams in 2014. The conventions and enforced structure solved real problems around code consistency and onboarding. In a different context — a small startup with a single co-located team — Backbone's flexibility might have been the better call.
+
+**Framework choice is mostly about people, not technology.** The technical capabilities of Ember and Backbone/Marionette were comparable. The difference was in how they affected team dynamics. An opinionated framework reduces the surface area for disagreement. In a distributed team, that's worth a lot.
+
+**The skills transfer, the frameworks don't.** I haven't written Ember in years, but the muscle memory of thinking about conventions, maintainability, and team-scale architecture is something I use every day. The specific syntax doesn't matter. The habits do.
+
+**Write things down.** That framework analysis document was one of the most valuable things I produced at Fidelity — not because the conclusion was surprising, but because the structured evaluation gave the team confidence in the decision. When you're making technology choices that will affect a team for years, putting the reasoning in writing forces clarity and creates a reference point for future decisions.

--- a/src/content/blog/routable-modals-browser-extension.md
+++ b/src/content/blog/routable-modals-browser-extension.md
@@ -1,0 +1,40 @@
+---
+title: "Routable Modals in a Browser Extension"
+description: "Solving the 'modal on top of route' problem with ModalBackgroundWrapper and React Router"
+pubDate: 2024-03-01
+tags: ["code"]
+draft: true
+---
+
+Browser extensions use React Router for navigation, but modals need to overlay on top of existing routes without replacing them. When a user opens "Receive" as a modal, the home screen should still be visible behind it. If they refresh the page or open the modal URL directly, it should still work.
+
+## The Solution
+
+[#4325](https://github.com/leather-io/extension/pull/4325) (+504/-297, 30 files) introduced:
+
+- **`ModalBackgroundWrapper`** - allows overlaying modals above other routes, showing the correct background behind nested routes
+- **`useBackgroundLocationRedirect`** - when pages are visited directly or opened in new tabs, properly sets the content behind them
+
+The PR has a [video demo](https://github.com/leather-io/extension/pull/4325) showing how it works.
+
+## The Journey
+
+1. [#4351 - "Stab at routing"](https://github.com/leather-io/extension/pull/4351) (+92/-90) -- first exploratory attempt
+2. [#4325 - The real fix](https://github.com/leather-io/extension/pull/4325) (+504/-297) -- ModalBackgroundWrapper + useBackgroundLocationRedirect
+3. Various follow-up fixes for edge cases (#4673 - brc-20 modal bg location, #5146 - send flow routing)
+
+## Known Remaining Issues
+
+Found but documented honestly in the PR:
+- Secret key view + settings menu: modal doesn't display until password entered
+- Direct access to `/receive/collectible/ordinal` crashes (missing taproot address)
+
+<!-- ADD: Had you dealt with this kind of routing problem before? How did you discover the ModalBackgroundWrapper approach -- was it inspired by something you'd seen elsewhere? The "Stab at routing" PR title suggests it wasn't obvious from the start. -->
+
+## Related Issues
+
+- [#5066](https://github.com/leather-io/extension/issues/5066) (P1) - Fix redirect for API request instead of home on unlock
+- [#4783](https://github.com/leather-io/extension/issues/4783) (P2) - Sign out shows password page
+- [#5143](https://github.com/leather-io/extension/issues/5143) (P3) - Ledger routing issue when rejecting
+
+Browser extension routing is its own special hell. You have popup mode, full-page tab mode, and action popups from dApps. Modals need to work in all three. React Router wasn't designed for this.

--- a/src/content/blog/shipping-mobile-app-from-scratch.md
+++ b/src/content/blog/shipping-mobile-app-from-scratch.md
@@ -1,0 +1,96 @@
+---
+title: "Shipping a Crypto Wallet Mobile App From Scratch (As a React Native Newcomer)"
+description: "From zero React Native experience to App Store in 3 months, launching at BTC Vegas"
+pubDate: 2024-12-15
+tags: ["code"]
+draft: true
+---
+
+<!-- ADD: What were you working on before this? What made you want to take on the mobile app? -->
+
+I'd never used React Native or Expo before. I'd been working on the browser extension -- design system migration, containers, routing -- and was about to tackle something completely new. The monorepo (`leather-io/mono`) was set up by the team, with the foundational packages and architecture already in place. Other team members were building the data layer, queries, and API integrations. My focus would be the mobile UI and features. My first PR was [#417](https://github.com/leather-io/mono/pull/417) -- adding a native Skeleton Loader to the UI library. In September 2024.
+
+By December 2024, the team shipped to the App Store. At BTC Vegas.
+
+<!-- ADD: The BTC Vegas story. Were you onsite? What was the atmosphere like shipping at a conference? Any last-minute drama? -->
+
+## Phase 1: Building Blocks (Sep 2024)
+
+Coming from a browser extension codebase, React Native was a shift. No CSS Grid. No `position: fixed`. Different scrolling behaviour. Different modal patterns.
+
+My first contributions were shared UI primitives in `packages/ui`:
+
+- **[#426](https://github.com/leather-io/mono/pull/426) - Sheet component** (+899/-753) - Bottom sheets are the bread and butter of mobile UX. This was my introduction to React Native animation.
+- **[#417](https://github.com/leather-io/mono/pull/417) - Skeleton Loader** (+237/-6) - Custom loading placeholders with animation variants.
+- **[#434](https://github.com/leather-io/mono/pull/434) - SheetHeader** - Refactored ModalHeader for mobile context.
+- **[#439](https://github.com/leather-io/mono/pull/439) - Accounts Widget** (+533/-189) - First real "feature" on mobile.
+
+These weren't flashy, but they were the vocabulary the entire mobile app would be written in.
+
+<!-- ADD: What was the steepest learning curve in React Native? Animation? Navigation? Testing? What surprised you vs web development? -->
+
+## Phase 2: From Mockups to Live Data (Oct-Nov 2024)
+
+With UI primitives ready, I built the home screen widgets:
+
+- **[#448](https://github.com/leather-io/mono/pull/448) - Tokens Widget** (+933/-1,057) - Token holdings display
+- **[#481](https://github.com/leather-io/mono/pull/481) - Collectibles Widget** (+1,739/-70) - NFT gallery preview
+
+Then the critical moment: integrating real blockchain data through `LeatherQueryProvider`. The data layer -- queries, API services, balance calculations -- was built by other team members in shared packages. My job was wiring it into the mobile UI. The app went from showing hardcoded values to real Stacks balances. The first time you see your actual wallet balance render on a phone you helped build... that's a feeling.
+
+<!-- ADD: What was that moment like? Who else was working on the mobile app? How did the collaboration work -- were you pairing, async, in different timezones? -->
+
+## Phase 3: "Leatherhood" at BTC Vegas (Dec 2024)
+
+The push to production was a team effort. In the final weeks, everyone was focused on launch blockers. My contributions included:
+
+- Setting up **Maestro E2E tests** ([#726](https://github.com/leather-io/mono/pull/726)) covering wallet creation, restoration, balance display, network switching -- before launch, not after
+- Adding **dark mode** with animated transitions
+- Implementing **pull-to-refresh** for balance updates
+- Adding **network badges** so users know which network they're on
+- Hardcoding several broken translations that would have blocked the release
+- Fixing multiple App Store submission issues
+
+The whole team was shipping multiple PRs per day, each targeting a specific launch blocker.
+
+<!-- ADD: The BTC Vegas details. How many team members were there? What was the energy like? Any funny stories about last-minute fixes across the team? Was there a specific moment you all knew it was ready to ship? -->
+
+## Phase 4: Making It Production-Grade (Jan-May 2025)
+
+Post-launch was about depth and safety:
+
+**Security & Validation (Jan-Mar)**
+- **[#885](https://github.com/leather-io/mono/pull/885) - Branded Types for Bitcoin addresses** (+1,002/-233, 47 files) - Compile-time prevention of invalid addresses
+- **[#915](https://github.com/leather-io/mono/pull/915) - Compliance checks** (+592/-67) - Sanctions screening on mobile
+
+**Barcelona Offsite (Jan 2025)**
+During the team offsite in Barcelona, I shipped [#6085](https://github.com/leather-io/extension/pull/6085) -- UTXO consolidation. The fix was +6/-10 lines (removing validation that blocked users from sending BTC to themselves). Tiny change, huge user value. Sometimes the best code is the code you delete.
+
+<!-- ADD: What was the Barcelona offsite like? Was the UTXO fix a hackathon thing or something you'd been thinking about? -->
+
+**Quality Pass (Mar-May)**
+One of the biggest quality improvements I worked on was [#1130](https://github.com/leather-io/mono/pull/1130) -- 121 files adding loading states and error handling. The critical fix: preventing the app from briefly showing "$0" balances while data loads.
+
+In a crypto wallet, users seeing $0 when they have funds is a support nightmare. It's the worst bug a wallet can have -- not because it loses money, but because users *think* they've lost money.
+
+## What I Learned (As a React Native Newcomer)
+
+1. **UI primitives are worth the investment.** The time spent on Sheet, Dialog, and SkeletonLoader in month one saved weeks in months 3-6. Coming from the browser extension where I'd already done this work, I knew the payoff was real.
+2. **Feature flags are non-negotiable for mobile.** You can't un-ship a mobile release like you can revert a web deploy. Gating unfinished features behind flags let us merge to main continuously.
+3. **React Native is closer to web than you think.** The mental model transfers. The gotchas are in animation, navigation, and platform-specific behaviour -- not in the component model.
+4. **E2E tests before launch, not after.** Maestro caught regressions that unit tests missed. Worth the setup cost even under launch pressure.
+
+## Key PRs
+
+| PR | What | Stats | Context |
+|---|---|---|---|
+| [#417](https://github.com/leather-io/mono/pull/417) | Skeleton Loader (first RN PR) | +237/-6 | Sep 2024 |
+| [#426](https://github.com/leather-io/mono/pull/426) | Sheet component | +899/-753 | Sep 2024 |
+| [#439](https://github.com/leather-io/mono/pull/439) | Accounts widget | +533/-189 | Sep 2024 |
+| [#448](https://github.com/leather-io/mono/pull/448) | Tokens widget | +933/-1,057 | Sep 2024 |
+| [#481](https://github.com/leather-io/mono/pull/481) | Collectibles widget | +1,739/-70 | Sep 2024 |
+| [#726](https://github.com/leather-io/mono/pull/726) | Maestro E2E tests | +198/-1 | Dec 2024 |
+| [#885](https://github.com/leather-io/mono/pull/885) | Branded Types | +1,002/-233, 47 files | Feb 2025 |
+| [#915](https://github.com/leather-io/mono/pull/915) | Compliance checks | +592/-67 | Feb 2025 |
+| [#1130](https://github.com/leather-io/mono/pull/1130) | Loading states everywhere | +915/-518, 121 files | May 2025 |
+| [#6085](https://github.com/leather-io/extension/pull/6085) | UTXO consolidation | +6/-10 | Barcelona |

--- a/src/content/blog/type-safety-crypto-wallet.md
+++ b/src/content/blog/type-safety-crypto-wallet.md
@@ -1,0 +1,86 @@
+---
+title: "Type Safety Where It Matters: Branded Types in a Crypto Wallet"
+description: "Using TypeScript's type system to prevent sending funds to invalid addresses"
+pubDate: 2025-03-01
+tags: ["code"]
+draft: true
+---
+
+In a crypto wallet, sending to a wrong address means lost funds. There's no undo, no customer support, no chargeback. An address is just a string, and TypeScript's type system normally can't distinguish between a valid Bitcoin address, a Stacks address, a random string, or an empty string.
+
+Having worked in crypto for years, I understood these stakes viscerally. But seeing the codebase handle addresses as raw strings still made me uncomfortable. The team knew it was a problem too -- it just hadn't been prioritised yet.
+
+<!-- ADD: Any specific moment that triggered this work? A near-miss? A support ticket? Or just the general unease of seeing `string` everywhere? -->
+
+## The Problem
+
+Before this work, address handling in the codebase looked like this:
+
+```typescript
+function sendBtc(to: string, amount: number) { ... }
+```
+
+Nothing stops you from passing a Stacks address, a URL, or `"hello"` as the `to` parameter. The validation happened at runtime, deep in the send flow, often after the user had already filled out a form.
+
+To make things worse, we were already dealing with real bugs in this area. Issues like [#4444](https://github.com/leather-io/extension/issues/4444) (unable to send Ordinals -- confirmation screen doesn't appear) and [#5204](https://github.com/leather-io/extension/issues/5204) (send ordinal flow not working) showed that the send flow was fragile. These were P1 bugs blocking users from sending their NFTs.
+
+## Branded Types
+
+The approach I took was [TypeScript Branded Types](https://github.com/leather-io/mono/pull/885) for `BitcoinAddress`:
+
+```typescript
+type BitcoinAddress = string & { __brand: 'BitcoinAddress' };
+
+function validateBitcoinAddress(input: string): BitcoinAddress | null {
+  // Validate against all Bitcoin address formats
+  // (P2PKH, P2SH, Bech32, Bech32m, Taproot)
+  if (isValid) return input as BitcoinAddress;
+  return null;
+}
+
+function sendBtc(to: BitcoinAddress, amount: number) { ... }
+```
+
+Now `sendBtc("hello", 100)` is a **compile-time error**. You can only pass a `BitcoinAddress`, and the only way to get one is through the validation function. The type system enforces that validation has happened.
+
+## The Implementation
+
+The PR ([#885](https://github.com/leather-io/mono/pull/885), +1,002/-233, 47 files) touched 47 files because every place that handled Bitcoin addresses needed to go through the validation gate:
+
+- **Send flow** - address input validation
+- **Address display** - ensuring displayed addresses are validated
+- **Transaction construction** - type-safe address parameters
+- **QR code scanning** - validated on decode
+
+Combined with Stacks address validation and transaction validation (with analytics tracking for malformed attempts), the wallet gained defence-in-depth against address errors.
+
+<!-- ADD: Was there pushback on touching 47 files for a type-safety change? How did the team react? Did you find any latent bugs during the migration? -->
+
+## Compliance Layer
+
+Beyond address format validation, the compliance checking system also needed to come to mobile ([#915](https://github.com/leather-io/mono/pull/915), +592/-67). The extension already had this -- the team had built the compliance integration there. My job was migrating it to the mobile send flow.
+
+`useBreakOnNonCompliantEntity` prevents the send flow from continuing if the recipient is on a sanctioned list. This is a legal requirement for crypto wallets operating in regulated jurisdictions.
+
+## The Anti-Phishing Angle
+
+Another security concern the team addressed was filtering URLs from token metadata ([#5589](https://github.com/leather-io/extension/issues/5589)). Malicious actors were airdropping tokens with phishing URLs baked into their metadata, which would then display in the wallet UI. A simple filter, but important for protecting users who might click without thinking.
+
+## The Takeaway
+
+In fintech/crypto, the type system isn't just about developer experience -- it's a safety mechanism. Branded Types turn "we validate this at runtime somewhere" into "this is provably validated, enforced by the compiler." For a wallet handling real money, that distinction matters.
+
+The compliance and anti-phishing work sits alongside this as part of a broader responsibility: when you're building a wallet, you're not just building software. You're building something that holds people's money.
+
+## Key PRs
+
+| PR | What | Stats |
+|---|---|---|
+| [#885](https://github.com/leather-io/mono/pull/885) | BTC validation + branded address types | +1,002/-233, 47 files |
+| [#915](https://github.com/leather-io/mono/pull/915) | Compliance checks on mobile | +592/-67, 13 files |
+
+### Related Issues (P1 bugs this prevents)
+- [#4444](https://github.com/leather-io/extension/issues/4444) - Unable to send Ordinals
+- [#5204](https://github.com/leather-io/extension/issues/5204) - Send ordinal flow not working
+- [#5253](https://github.com/leather-io/extension/issues/5253) - Ledger inscription sending broken
+- [#5589](https://github.com/leather-io/extension/issues/5589) - Anti-phishing: filter URLs from token metadata

--- a/src/content/blog/utxo-consolidation-six-lines.md
+++ b/src/content/blog/utxo-consolidation-six-lines.md
@@ -1,0 +1,26 @@
+---
+title: "The Six-Line Fix: UTXO Consolidation at the Barcelona Offsite"
+description: "Sometimes the best code is the code you delete. +6/-10 lines, merged same day."
+pubDate: 2025-01-20
+tags: ["code"]
+draft: true
+---
+
+During the team offsite in Barcelona (Jan 2025), I shipped [#6085](https://github.com/leather-io/extension/pull/6085) -- enabling UTXO consolidation by removing validation that blocked users from sending BTC to themselves.
+
+**The entire PR: +6/-10 lines, 3 files, merged same day.**
+
+The fix: remove `sameAddressError` validation from the send flow. The validation existed to prevent users from accidentally sending to themselves. But it also prevented UTXO consolidation -- a legitimate and useful Bitcoin operation where you combine multiple small UTXOs into one larger one by sending to your own address.
+
+## Why It Matters
+
+UTXO consolidation is important for Bitcoin users because:
+
+- Many small UTXOs = higher transaction fees (each UTXO adds to tx size)
+- Consolidating during low-fee periods saves money on future transactions
+- Power users and Lightning node operators need this regularly
+- This was an open issue for a while: [leather-io/extension#5349](https://github.com/leather-io/extension/issues/5349)
+
+<!-- ADD: Was this a hackathon project? How did you find this issue? What was the Barcelona offsite like? Was it a team hackathon or did you just pick this up between sessions? Any reactions from users after it shipped? -->
+
+A story about questioning assumptions, small changes with outsized user impact, and the offsite energy that lets you pick up lingering issues.


### PR DESCRIPTION
## Summary
- 13 blog post drafts covering ~2.5 years of open-source contributions to [Leather wallet](https://leather.io/)
- 2 early career posts (telco monitoring tool, Fidelity framework analysis)
- 1 human-readable Ethereum transactions post
- 2 Cryptowatch/Kraken posts (Coderunner trading automation, Cockpit portfolio table)
- All posts set as `draft: true` — they build but don't render on the live site
- Each post has `<!-- ADD: -->` comment prompts where personal stories and context should be added

**Leather narrative series (4 posts):** Multi-protocol NFT collectibles, cross-platform monorepo, TypeScript branded types, mobile app launch story

**Leather technical notes (4 posts):** Container architecture iterations, design system migration, UTXO consolidation, routable modals

**Expo series (5 posts):** CI/CD fingerprinting, secure storage & biometrics, multi-chain architecture, OTA updates, alternate app icons

**Cryptowatch/Kraken (2 posts):** Coderunner trading automation tool, Cockpit portfolio table and trading UI

**Early career (2 posts):** Telco monitoring tool, Fidelity JavaScript framework analysis

**Other (1 post):** Human-readable Ethereum transactions