### PR TITLE
feat: add /cv route with markdown-driven CV page

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -8,5 +8,6 @@ const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 <nav>
   <a href={ROUTES.ABOUT} class={pathname === ROUTES.ABOUT ? 'active' : ''}>About</a>
   <a href={ROUTES.BLOG} class={pathname.startsWith(ROUTES.BLOG) ? 'active' : ''}>Blog</a>
+  <a href={ROUTES.CV} class={pathname === ROUTES.CV ? 'active' : ''}>CV</a>
   <SocialMedia />
 </nav>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -5,6 +5,7 @@ export const ROUTES = {
   HOME: '/',
   ABOUT: '/about',
   BLOG: '/blog',
+  CV: '/cv',
 } as const;
 
 export const SOCIAL = {

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -11,4 +11,19 @@ const blog = defineCollection({
   }),
 });
 
-export const collections = { blog };
+const cv = defineCollection({
+  type: 'content',
+  schema: z.object({
+    tagline: z.string(),
+    contact: z.object({
+      website: z.string(),
+      email: z.string(),
+      linkedin: z.string(),
+      github: z.string(),
+      stackoverflow: z.string(),
+      location: z.string(),
+    }),
+  }),
+});
+
+export const collections = { blog, cv };

--- a/src/content/cv/index.md
+++ b/src/content/cv/index.md
@@ -1,0 +1,115 @@
+---
+tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native"
+contact:
+  website: "https://petewatters.ie"
+  email: "pete@cteic.ie"
+  linkedin: "https://www.linkedin.com/in/pete-watters/"
+  github: "https://github.com/pete-watters"
+  stackoverflow: "https://stackoverflow.com/users/1365580/peadar"
+  location: "Dublin, Ireland (remote only)"
+---
+
+Senior Frontend Engineer with 15+ years building secure, high-stakes web applications — from TradFi at Fidelity Investments and Bank of America Merrill Lynch, through OG crypto infrastructure at Xapo and Kraken/Cryptowatch, to Web3 and DeFi products at Qredo and Trust Machines/Leather. Deep expertise in React, TypeScript, React Native, and frontend architecture, with a strong track record in CI/CD, developer tooling, and client-side security. Experienced technical interviewer, mentor, and testing advocate.
+
+## Work Experience
+
+### [Trust Machines](https://trustmachines.co) · Senior Frontend Engineer
+
+*July 2023 — Present · Remote*
+
+> Building the largest ecosystem of Bitcoin applications on the Stacks network. Open-source contributor to the [Leather](https://leather.io/) Web3 Bitcoin wallet.
+
+- Contributed to the Hiro Wallet to Leather rebrand as part of the core team: helped architect the mono-repo, built the shared Panda UI component package including BIP key validation on the mnemonic login form, delivering a redesigned experience serving **8,400+ monthly active extension users** (62,000+ over six months).
+- Stepped up to **lead the first Leather mobile app launch** (React Native + Expo) end-to-end — self-funded the trip to attend the **Bitcoin Conference 2025 in Las Vegas** for the launch — growing to **1,850+ monthly active users within three months** on iOS and Android.
+- Established frontend engineering standards for the mono-repo, enabling multiple product teams to ship faster with shared tooling and a consistent design system.
+- Building at the frontier of **Bitcoin DeFi**: Leather acts as a signer for BTC DeFi protocols, with integrations for **Granite and Zest**. Built the **Leather DeFi Portfolio table UI**, giving users a unified view of their on-chain DeFi positions.
+
+### [Qredo](https://www.qredo.com) · Senior Frontend Engineer
+
+*January 2023 — June 2023 · Remote*
+
+> Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
+
+- **Led Web3 wallet integration** and built a greenfield institutional trading interface using React, Redux Toolkit, Material UI, and styled-components — integrating MetaMask, WalletConnect, and WebAPI to enable clients to connect and transact securely on the Qredo network.
+- Built a **Node.js ETH transaction parser** making on-chain history human-readable, improving compliance and operational transparency.
+
+### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer
+
+*August 2020 — November 2022 · Remote*
+
+> [Cryptowatch](https://blog.kraken.com/product/cryptowatch-to-sunset-kraken-pro-to-integrate-cryptowatch-features): a widely popular real-time charting and trading terminal in the crypto community, acquired by Kraken and later absorbed to create the new Kraken Pro interface. Served millions of active traders across 25 integrated exchanges and 4,000+ markets.
+
+- Spent a year on the **Cryptowatch trading team** building the multi-exchange trading form, cockpit redesign, and a custom trade table — mission-critical, high-traffic infrastructure with direct visibility from executive leadership. This work became the foundation for **Kraken Pro** today.
+- Subsequently the sole frontend engineer on **Coderunner**, a greenfield trading automation tool. Built the entire frontend in **8 months**: React/TypeScript/PostCSS with a custom dynamic form-generation system enabling consistent field types including market picker, asset-aware amount input, and precision-aware currency handling.
+- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project; won the company-wide Codebashing security challenge (2020), placing first for knowledge of client-side vulnerabilities and OWASP mitigations.
+
+### [Xapo](https://www.xapo.com) · Senior Frontend Engineer / Solutions Architect
+
+*Nov 2017 — April 2020 · Remote*
+
+> Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services.
+
+- Designed the **full-stack application architecture blueprint** using React, Next.js, and Express, adopted across multiple product teams as the company's engineering standard.
+- Implemented **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and enabling faster, more reliable releases.
+- Mentored engineers on testing practices and architecture patterns; acted as technical bar-raiser during hiring across the engineering org.
+- Completed **private blockchain engineering training** — live sessions and a multi-day Bitcoin programming course (entry required passing a Python coding assessment).
+
+### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Frontend Architect, Ember.js Lead
+
+*May — Oct 2017 · On-site*
+
+> One of the world's largest financial institutions with $3+ trillion in assets under management.
+
+- Embedded as **Ember.js subject-matter expert** in a team of 6, working across the stack with Python and Django to deliver investment performance tracking software.
+- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow for the first time — became the team's standard practice. Delivered a programme of technical presentations raising team quality standards.
+
+### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer
+
+*April 2016 — March 2017 · On-site*
+
+> Web-based design tool for customised decal manufacture. Hired to rescue a failing legacy Ember.js and Fabric.js application.
+
+- Delivered the **first stable production release in 7 months**, cutting test cycle time by 70%. Architected full CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Hired a team of two to replace the outgoing engineering team, reporting directly to CEO and CTO.
+
+### Kontainers · Full-Stack Developer
+
+*June 2015 — April 2016 · Remote*
+
+> Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
+
+- Recruited by co-founder and CTO to take the product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD) — establishing engineering culture at seed stage.
+
+### [Fidelity Investments](https://www.fidelity.com) · UX Developer
+
+*June 2014 — June 2015 · On-site*
+
+> Global financial services corporation managing $11+ trillion in assets under management.
+
+- Technical lead for an offshore development team, travelling to the UK and India for hands-on direction. Represented the engineering function during **Enterprise Ireland R&D accreditation**.
+
+### Earlier Career
+
+*2006 — 2014*
+
+Ad Technology Producer — Yahoo! (2013–2014) · UX Developer — eSpatial (2012–2013) · Operations Engineer — The Now Factory (2010–2012) · Technical Support / QA — Ocuco, IBM, Hewlett Packard (2006–2010)
+
+## Education
+
+### MEng Telecommunications Engineering · DCU
+
+Awarded master's scholarship based on undergraduate performance. Completed while working full-time.
+
+### BEng Digital Media Engineering · Dublin City University (DCU)
+
+Graduated in the top 3 of my class — the performance that earned the master's scholarship.
+
+## Certifications & Recognition
+
+### C4 Certified Bitcoin Professional
+
+Bitcoin protocol, cryptographic security, wallets and ecosystem.
+
+### Kraken / Cryptowatch Codebashing Champion (2020)
+
+First company-wide in a security challenge on client-side vulnerabilities and OWASP principles.

--- a/src/layouts/CvLayout.astro
+++ b/src/layouts/CvLayout.astro
@@ -1,0 +1,261 @@
+---
+import Icon from '../components/Icon.astro';
+import '../styles/global.css';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+
+interface Props {
+  title?: string;
+  description?: string;
+  tagline: string;
+  contact: {
+    website: string;
+    email: string;
+    linkedin: string;
+    github: string;
+    stackoverflow: string;
+    location: string;
+  };
+}
+
+const { title, description, tagline, contact } = Astro.props;
+const pageTitle = title ? `${title} | ${SITE_TITLE}` : SITE_TITLE;
+const pageDescription = description ?? SITE_DESCRIPTION;
+---
+
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="description" content={pageDescription} />
+    <meta name="theme-color" content="#2b2b2b" />
+    <link rel="shortcut icon" href="/img/favicon.ico" />
+    <link rel="apple-touch-icon" sizes="180x180" href="/img/apple-touch-icon.png" />
+    <link rel="icon" type="image/png" sizes="32x32" href="/img/favicon-32x32.png" />
+    <link rel="icon" type="image/png" sizes="16x16" href="/img/favicon-16x16.png" />
+    <link rel="mask-icon" href="/img/safari-pinned-tab.svg" color="#5bbad5" />
+    <meta name="msapplication-TileColor" content="#da532c" />
+    <title>{pageTitle}</title>
+  </head>
+  <body>
+    <header>
+      <div class="header-inner">
+        <h1><a href="https://petewatters.ie">Pete Watters</a></h1>
+      </div>
+    </header>
+    <main>
+      <div class="cv">
+        <div class="cv-intro">
+          <p class="tagline">{tagline}</p>
+          <div class="contact">
+            <a href={contact.website}>{contact.website.replace('https://', '')}</a>
+            <span class="sep">·</span>
+            <a href={`mailto:${contact.email}`}>{contact.email}</a>
+            <span class="sep">·</span>
+            <a href={contact.linkedin} target="_blank" rel="noopener noreferrer">
+              <Icon name="linkedin" /> LinkedIn
+            </a>
+            <span class="sep">·</span>
+            <a href={contact.github} target="_blank" rel="noopener noreferrer">
+              <Icon name="github" /> GitHub
+            </a>
+            <span class="sep">·</span>
+            <a href={contact.stackoverflow} target="_blank" rel="noopener noreferrer">
+              <Icon name="stackoverflow" /> StackOverflow
+            </a>
+            <span class="sep">·</span>
+            <span class="location">{contact.location}</span>
+          </div>
+        </div>
+        <slot />
+      </div>
+    </main>
+  </body>
+</html>
+
+<style>
+  header {
+    display: block;
+    padding: 1rem 2rem;
+  }
+
+  .header-inner {
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 0;
+  }
+
+  .header-inner :global(h1) {
+    margin: 0;
+    text-align: left;
+  }
+
+  main {
+    text-align: left;
+    display: block;
+    max-width: 52rem;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  .cv-intro {
+    margin-bottom: 1.5rem;
+    border-bottom: 2px solid #cccccc;
+    padding-bottom: 1rem;
+  }
+
+  .tagline {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 1rem;
+    color: #555555;
+    margin: 0 0 0.75rem 0;
+  }
+
+  .contact {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    gap: 0.4rem;
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+  }
+
+  .contact a {
+    font-family: 'Roboto Mono', monospace;
+    display: inline-flex;
+    align-items: center;
+    gap: 0.2rem;
+    color: #111111;
+  }
+
+  .contact :global(svg) {
+    width: 14px;
+    height: 14px;
+  }
+
+  .sep {
+    font-family: 'Roboto Mono', monospace;
+    color: #cccccc;
+  }
+
+  .location {
+    font-family: 'Roboto Mono', monospace;
+    color: #555555;
+  }
+
+  /* Section headings: Work Experience, Education, etc. */
+  .cv :global(h2) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 1.1rem;
+    letter-spacing: 2.5px;
+    text-transform: uppercase;
+    font-weight: 700;
+    border-bottom: 2px solid #111111;
+    padding-bottom: 0.25rem;
+    margin: 2rem 0 1rem;
+  }
+
+  /* Job company + title lines */
+  .cv :global(h3) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.95rem;
+    font-weight: 700;
+    margin: 1.5rem 0 0.25rem;
+  }
+
+  .cv :global(h3 a) {
+    font-family: 'Roboto Mono', monospace;
+    font-weight: 700;
+    opacity: 1;
+    text-decoration: underline;
+  }
+
+  /* Date/location metadata lines (paragraphs containing only em) */
+  .cv :global(p:has(> em:only-child)) {
+    margin: 0 0 0.25rem;
+  }
+
+  .cv :global(p > em:only-child) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    color: #888888;
+  }
+
+  /* Job context blockquotes */
+  .cv :global(blockquote) {
+    margin: 0.5rem 0;
+    padding: 0 0 0 1rem;
+    border-left: 3px solid #cccccc;
+    color: #555555;
+  }
+
+  .cv :global(blockquote p) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  /* Bullet points */
+  .cv :global(ul) {
+    margin: 0.5rem 0;
+    padding-left: 1.25rem;
+  }
+
+  .cv :global(li) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.8rem;
+    line-height: 1.6;
+    margin-bottom: 0.4rem;
+    color: #111111;
+  }
+
+  /* Regular paragraphs */
+  .cv :global(p) {
+    font-family: 'Roboto Mono', monospace;
+    font-size: 0.85rem;
+    line-height: 1.6;
+    color: #111111;
+  }
+
+  /* Links in body */
+  .cv :global(a) {
+    color: #111111;
+  }
+
+  /* Print styles */
+  @media print {
+    header {
+      padding: 0.5rem 1rem;
+    }
+
+    header :global(h1) {
+      font-size: 1.5rem;
+    }
+
+    main {
+      padding: 0 1rem;
+    }
+
+    .cv-intro {
+      margin-bottom: 1rem;
+      padding-bottom: 0.75rem;
+    }
+
+    .cv :global(h2) {
+      margin: 1.25rem 0 0.5rem;
+    }
+
+    .cv :global(h3) {
+      margin: 1rem 0 0.15rem;
+    }
+
+    .cv :global(li) {
+      margin-bottom: 0.2rem;
+    }
+
+    .cv :global(blockquote) {
+      margin: 0.25rem 0;
+    }
+  }
+</style>

--- a/src/pages/cv.astro
+++ b/src/pages/cv.astro
@@ -1,0 +1,18 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import CvLayout from '../layouts/CvLayout.astro';
+import { getCollection, render } from 'astro:content';
+
+const entries = await getCollection('cv');
+const entry = entries[0] as CollectionEntry<'cv'>;
+const { Content } = await render(entry);
+---
+
+<CvLayout
+  title="CV"
+  description="Pete Watters — Senior Frontend Engineer CV"
+  tagline={entry.data.tagline}
+  contact={entry.data.contact}
+>
+  <Content />
+</CvLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -76,7 +76,7 @@ header {
   display: grid;
   grid-template-columns: 2fr 1fr;
   grid-template-areas: "logo nav";
-  padding: 1rem;
+  padding: 1rem 2rem;
   background-color: #2B2B2B;
   color: white;
 }


### PR DESCRIPTION
## Summary
- Adds a `/cv` route with CV content as a markdown file (`src/content/cv/index.md`) using Astro content collections — same pattern as the blog
- Dedicated `CvLayout` with logo-only header (no nav), scoped CV styling mapping markdown elements to structured CV design, and print-friendly `@media print` rules
- Contact bar with LinkedIn, GitHub, and StackOverflow SVG icons and labels
- Company names are real clickable links throughout
- CV link added to site navigation on all other pages
- Header padding aligned sitewide so logo matches content margin

## Test plan
- [ ] Visit `/cv` — page renders with logo header, contact bar, full CV content
- [ ] Company names (Trust Machines, Kraken, Xapo, etc.) are clickable links
- [ ] LinkedIn/GitHub/StackOverflow icons render in contact bar
- [ ] Header logo links to https://petewatters.ie
- [ ] No duplicate "Pete Watters" in body, no "founded by" phrases in summary
- [ ] Other pages (/, /about, /blog) still have full nav with new CV link
- [ ] Print to PDF (Cmd+P → A4, background graphics on) produces clean output
- [ ] Mobile/responsive layout works

🤖 Generated with [Claude Code](https://claude.com/claude-code)