### PR TITLE
blog: add 6 draft posts on Leather open-source work

### DIFF
--- a/src/content/blog/designing-a-monorepo.md
+++ b/src/content/blog/designing-a-monorepo.md
@@ -1,0 +1,68 @@
+---
+title: "Designing a Monorepo for a Browser Extension and Mobile App"
+description: "How I set up and designed the monorepo architecture for Leather wallet — consolidating a browser extension, mobile app, and shared packages into a single repository with automated publishing."
+pubDate: 2026-02-27
+tags: ["open-source", "monorepo", "devops", "leather"]
+draft: true
+---
+
+The [Leather](https://leather.io) wallet started as a single repository — a Chrome extension built with React. Then came the mobile app. Then shared packages for crypto utilities, UI components, and API clients. Two apps, growing apart, duplicating code.
+
+I designed and implemented the [monorepo](https://github.com/leather-wallet/mono) that brought them together.
+
+## Why a monorepo
+
+The extension and mobile app shared a significant amount of code — query hooks, crypto utilities, type definitions, and increasingly, UI components. Before the monorepo, changes to shared logic meant:
+
+1. Update the package in its own repo
+2. Publish a new version
+3. Update the dependency in both consuming repos
+4. Hope nothing broke in the version gap
+
+With a monorepo, a change to a shared package is immediately available to both apps. CI runs tests for everything affected. No version drift, no publish-and-pray.
+
+## The structure
+
+```
+leather-wallet/mono/
+├── apps/
+│   ├── extension/     # Chrome/Firefox browser extension
+│   └── mobile/        # React Native mobile app
+├── packages/
+│   ├── ui/            # Shared UI component library
+│   ├── crypto/        # Crypto utilities, key management
+│   ├── query/         # Shared API queries and hooks
+│   └── utils/         # Common utilities
+├── pnpm-workspace.yaml
+└── turbo.json
+```
+
+[pnpm workspaces](https://pnpm.io/workspaces) handle dependency resolution and linking. [Turborepo](https://turbo.build/repo) handles task orchestration — running builds, tests, and linting in the right order with caching.
+
+## Key decisions
+
+**pnpm over npm/yarn.** pnpm's strict dependency resolution catches phantom dependencies — packages that work by accident because a sibling package installed them. In a monorepo with shared packages, this strictness prevents subtle runtime errors where code works locally but breaks in production.
+
+**Turborepo for task orchestration.** The dependency graph between packages means `packages/ui` needs to build before `apps/extension` can build. Turborepo understands this graph and parallelises everything it can while respecting build order. Remote caching means CI doesn't rebuild unchanged packages.
+
+**Shared tsconfig and ESLint configs.** A base TypeScript config lives at the root. Each package extends it with its own needs (DOM types for the extension, React Native types for mobile). Same pattern for ESLint — shared rules at the root, package-specific overrides where needed.
+
+## Automated publishing
+
+Shared packages need to be published for external consumers and for the mobile app's Expo build (which can't use workspace links). I set up automated publishing via GitHub Actions ([PR #8](https://github.com/leather-wallet/mono/pull/8)) — on merge to main, changed packages get version-bumped and published to npm automatically.
+
+The workflow detects which packages have changed using Turborepo's `--filter` flag, runs their build and test pipelines, and publishes only what's new. No manual version bumping, no forgetting to publish after a merge.
+
+## What I learned
+
+**Start with the dependency graph.** Before writing any config, I mapped out which packages depend on which. This drove the workspace structure and revealed circular dependencies that needed breaking.
+
+**Migrate incrementally.** The extension moved in first, then shared packages were extracted one at a time, then the mobile app joined. Trying to do it all at once would have been a multi-week block on the entire team.
+
+**Invest in DX early.** A monorepo with poor developer experience is worse than separate repos. Fast builds (Turborepo caching), instant linking (pnpm workspaces), and automated publishing make the day-to-day experience better than what it replaced.
+
+## The result
+
+Both apps now share code through typed, tested packages. A change to a shared component is tested against both apps in CI before it merges. Publishing is automated. The team ships faster because cross-cutting changes are a single PR instead of a coordinated dance across repositories.
+
+The [initial setup commits](https://github.com/leather-wallet/mono/commits/main/) tell the story — workspace config, turborepo pipeline, CI workflows, then the apps and packages migrating in one by one.

--- a/src/content/blog/full-page-containers-extension.md
+++ b/src/content/blog/full-page-containers-extension.md
@@ -1,0 +1,74 @@
+---
+title: "Rebuilding a Browser Extension's Container System from Scratch"
+description: "How I replaced the entire drawer and container system in a crypto wallet extension with full-page views, shared headers, and a new design system implementation."
+pubDate: 2026-02-27
+tags: ["open-source", "react", "design-system", "leather"]
+draft: true
+---
+
+This is the story of a PR that touched nearly 100 files, replaced the entire container system, and fixed 8 bugs in the process. [PR #4655](https://github.com/leather-wallet/extension/pull/4655) — 4,990 additions, 5,113 deletions.
+
+The [Leather](https://leather.io) wallet extension had accumulated layers of layout components over time. `BaseDrawer`, `ControlledDrawer`, `CenteredPageContainer`, `ModalHeader`, a custom `Header` component — each solving a slightly different layout problem, each with its own quirks. The design team had moved to a new container system in Figma. The code hadn't caught up.
+
+## The problems
+
+The extension runs in two modes: a 360px popup and a full-page tab view. The old code treated these differently. Popup width wasn't standardised — some views were wider than others. Modals looked different depending on which drawer component rendered them. The settings menu was a bespoke implementation that didn't match the new designs.
+
+And the drawers. The `BaseDrawer` was a 127-line component with its own animation logic, scroll handling, and close behaviour. `ControlledDrawer` wrapped it with state management. Both were used inconsistently throughout the app.
+
+## The approach
+
+Rather than patch the existing system, I replaced it. The work broke down into clear steps:
+
+1. **Replace `BaseDrawer` with Radix `Dialog`.** Radix handles focus trapping, scroll locking, and accessibility out of the box. No more custom animation code.
+
+2. **Unify all headers.** The old codebase had `Header`, `ModalHeader`, and `DrawerHeader` — three components doing roughly the same thing. I consolidated them into composable header components that work in every context.
+
+3. **Standardise viewport width.** Extension popup and popout mode now use the same width. No more layout shifts when a view opens in a different context.
+
+4. **Move CSS from app to UI library.** Radix styles and global CSS were imported at the app level. I moved them into the shared UI library so they're available everywhere and managed in one place.
+
+5. **Implement screen variants.** Background colours now change based on screen type — "home", "page", "modal" — driven by a single container component instead of scattered inline styles.
+
+6. **Refactor `navigate` out of layout components.** Headers and dialogs were calling `useNavigate` internally, coupling layout to routing. I lifted navigation handlers to the page level and passed them as props.
+
+## What got deleted
+
+- `BaseDrawer` (127 lines)
+- `ControlledDrawer` (30 lines)
+- `CenteredPageContainer` (15 lines)
+- `Header` (86 lines)
+- `ModalHeader` (86 lines)
+- `DrawerHeader` (56 lines)
+- `HeaderActionButton` (34 lines)
+- `PreviewButton` (24 lines)
+- `LeatherLogo` component (23 lines)
+- `NetworkModeBadge` (33 lines)
+- `useRouteHeader` hook (16 lines)
+- `useDrawers` hook (26 lines)
+- `useEventListener` hook (74 lines)
+- `useMediaQuery` hook (23 lines)
+
+Over 600 lines of layout primitives replaced by Radix Dialog and a single composable container system.
+
+## What got added
+
+The new `Container` component handles everything. It reads the current route and applies the correct layout variant — header style, background colour, footer visibility. A set of utility functions (`getPopupHeader`, `getTitleFromUrl`, `routeHelpers`) derive layout state from the URL.
+
+New Storybook stories document each container variant. Chromatic visual regression testing catches layout changes across the full matrix of screen sizes and variants.
+
+## The bugs it fixed
+
+Because the old system was fragmented, bugs lived in the gaps between components. This refactor closed 8 open issues:
+
+- Popup background colour inconsistencies
+- Settings sub-menu rendering issues
+- Scroll behaviour differences between popup and tab
+- Sign-out layout not matching designs
+- Fund page layout broken in popout mode
+
+When your layout system is unified, entire categories of bugs disappear.
+
+## Takeaway
+
+Sometimes the right refactor is the big one. Patching 6 different drawer components to match a new design system would have taken longer and left the same fragmentation in place. One focused PR that replaces the entire container layer is easier to review (despite the line count), easier to maintain going forward, and fixes bugs you didn't even set out to fix.

--- a/src/content/blog/mnemonic-validation-wallet-sign-in.md
+++ b/src/content/blog/mnemonic-validation-wallet-sign-in.md
@@ -1,0 +1,60 @@
+---
+title: "Redesigning Wallet Onboarding: Mnemonic Validation with @scure/bip39"
+description: "How I rebuilt the sign-in form for a crypto wallet browser extension — replacing a single textarea with word-by-word mnemonic input and real-time BIP-39 validation."
+pubDate: 2026-02-27
+tags: ["open-source", "react", "crypto", "leather"]
+draft: true
+---
+
+Signing into a crypto wallet isn't like signing into a web app. There's no email field, no password reset. Your identity is a 12 or 24-word mnemonic phrase — get one word wrong and you're locked out of your funds.
+
+The old sign-in form in the [Leather](https://leather.io) browser extension was a single textarea. Paste your seed phrase, hit submit, hope for the best. No feedback until you submitted. No way to know which word was wrong.
+
+I wanted to fix that.
+
+## The problem
+
+A BIP-39 mnemonic phrase is drawn from a specific wordlist of 2,048 English words. Each word matters. A typo in word 9 of 24 is easy to miss in a wall of text, and the error message after submission doesn't tell you where the problem is.
+
+Users were getting stuck on onboarding. Support tickets came in from people who'd copied their phrase from a notebook and couldn't figure out which word had a typo.
+
+## The solution
+
+I replaced the textarea with individual input fields — one per word — each with real-time validation against the BIP-39 wordlist using [`@scure/bip39`](https://github.com/paulmillr/scure-bip39).
+
+```typescript
+import { wordlist } from '@scure/bip39/wordlists/english';
+
+function validateMnemonicWord(word: string): boolean {
+  return wordlist.includes(word.trim().toLowerCase());
+}
+```
+
+Each input validates on blur. If a word isn't in the BIP-39 wordlist, the field highlights immediately. No waiting until form submission to discover you typed "abandn" instead of "abandon".
+
+## Implementation
+
+The form is built with [Formik](https://formik.org) wrapping a grid of Radix UI `TextField` components. The key decisions:
+
+**Word-by-word input over a textarea.** More markup, but each word gets its own validation state. Users can tab between fields, paste a full phrase (which auto-distributes across fields), or type word by word.
+
+**Validation on blur, not on change.** Validating on every keystroke would flash errors while you're still typing "aban—". Blur gives you time to finish the word.
+
+**Shared layout with key display.** The sign-in form and the "view your secret key" screen share the same two-column grid layout. New key generation, sign-in, and key display all use the same visual treatment — from the [Figma design system](https://www.figma.com/file/2MLHeIeL6XPVi3Tc2DfFCr).
+
+The submit button is disabled until every word passes validation. No more submitting an invalid phrase and wondering what went wrong.
+
+## What changed
+
+| Before | After |
+|---|---|
+| Single textarea for entire phrase | Individual input per word |
+| Validation on submit only | Real-time validation on blur |
+| Generic error message | Per-word error highlighting |
+| No shared layout with key display | Shared two-column grid component |
+
+The PR ([#4243](https://github.com/leather-wallet/extension/pull/4243)) was 739 additions and 436 deletions across 27 files — including new E2E tests for the onboarding flow.
+
+## Takeaway
+
+Crypto UX has a reputation for being hostile to users. Seed phrases are already intimidating. The least we can do is tell people which word is wrong before they hit submit.

--- a/src/content/blog/modal-routing-browser-extension.md
+++ b/src/content/blog/modal-routing-browser-extension.md
@@ -1,0 +1,59 @@
+---
+title: "Fixing Modal Routing in a React Browser Extension"
+description: "How I refactored overlay modal routing in a browser extension to properly handle background content, direct navigation, and nested route state."
+pubDate: 2026-02-27
+tags: ["open-source", "react", "react-router", "leather"]
+draft: true
+---
+
+Browser extensions are weird. You've got a popup view that's 360px wide, a full-page tab view, and sometimes a notification window for transaction signing. All running the same React app, all sharing the same routes.
+
+Now add overlay modals — the "receive" sheet, the "switch account" dialog, the settings menu — that need to slide over whatever page you were on. In a regular web app, you'd just render a modal. In an extension, you need the background content to persist correctly across popup reopens, direct URL access, and nested route changes.
+
+This was broken in [Leather](https://leather.io). I fixed it in [PR #4325](https://github.com/leather-wallet/extension/pull/4325).
+
+## What was broken
+
+Two bugs, both related to background content behind modals:
+
+1. Open the settings menu, choose "View Secret Key", enter your password — the settings modal disappears until you authenticate. The background goes blank.
+2. Copy the URL for `/receive/collectible/ordinal` and open it in a new tab — crash. The page expects state from the parent route that doesn't exist when navigated to directly.
+
+The root cause was the same: the app had no concept of "what should be behind this modal."
+
+## The fix: background location state
+
+React Router's `useLocation` gives you the current location. But what we needed was a way to say "render this route as a modal overlay, and keep rendering _that other route_ behind it."
+
+I introduced two pieces:
+
+**`ModalBackgroundWrapper`** — a component that wraps modal routes and renders the correct background content behind them. It reads a `backgroundLocation` from route state and renders that location's content underneath the modal.
+
+**`useBackgroundLocationRedirect`** — a hook for pages that should always have background content. When visited directly (no background location in state), it redirects to itself with the correct background location injected.
+
+```typescript
+// When navigating to a modal route, pass the current location as background
+navigate('/receive', {
+  state: { backgroundLocation: location }
+});
+```
+
+The `ModalBackgroundWrapper` then renders two things: the background route (from state) and the foreground modal (from the URL). When someone opens a modal URL directly, the redirect hook sets up the background state automatically.
+
+## Route restructuring
+
+The routes file was a single flat list of 40+ routes. I broke it into logical groups:
+
+- `receive-routes.tsx` — all receive flows
+- `settings-routes.tsx` — settings and preferences
+- `request-routes.tsx` — transaction request handling
+- `rpc-routes.tsx` — RPC method routing
+- `ordinal-routes.tsx` — ordinal/inscription flows
+
+Each group is self-contained and easier to reason about. The main `app-routes.tsx` went from 173 lines of route definitions to 39 lines of group imports.
+
+## The result
+
+Both bugs fixed. Modals overlay correctly regardless of how you get there. Direct URL access works. The route file is readable. The PR was 504 additions and 297 deletions across 30 files.
+
+Browser extensions force you to think about navigation edge cases that web apps rarely hit. Every route needs to work when opened cold — no parent state, no navigation history, no assumptions.

--- a/src/content/blog/shipping-monster-prs.md
+++ b/src/content/blog/shipping-monster-prs.md
@@ -1,0 +1,41 @@
+---
+title: "Shipping a 5,000-Line PR Without Losing Your Mind"
+description: "Lessons from shipping massive pull requests on a crypto wallet — including a 5,783-addition PR that refactored collectibles across a monorepo."
+pubDate: 2026-02-27
+tags: ["open-source", "code-review", "process", "leather"]
+draft: true
+---
+
+Nobody wants to review a 5,000-line pull request. Nobody wants to write one either. But sometimes that's the size of the change.
+
+Working on the [Leather](https://leather.io) wallet, I shipped PRs that ranged from small bug fixes to sweeping refactors. Two of the largest — [PR #1903](https://github.com/leather-io/mono/pull/1903) (5,783 additions, 1,152 deletions) and [PR #2004](https://github.com/leather-io/mono/pull/2004) (1,485 additions) — taught me how to manage large changes without the review process falling apart.
+
+## Why some PRs can't be small
+
+PR #1903 refactored the entire collectibles system across the monorepo. It introduced a shared `CollectibleView` type, moved UI components from a shared package into their respective apps, added token detail screens, ported the "Send Inscription" flow, and added loading states — all of which depended on each other.
+
+You can't ship a shared type without the components that use it. You can't ship the components without the screens that render them. You can't ship the screens without the routes that mount them. The dependency chain makes it a single unit of work.
+
+PR #2004 was the gated follow-up — new collectible components behind a feature flag, maintaining production code alongside the new implementation. Still large because it introduced a complete parallel UI layer.
+
+## What makes a large PR reviewable
+
+**A clear PR description.** PR #1903's description has a feature checklist, a list of known follow-up work, a note about an external API issue (Gamma returning 500s), and a video demo. Reviewers can watch the 30-second demo and understand the change before reading a single line of code.
+
+**Feature flags for incremental rollout.** PR #2004 gated new components behind a `revampCollectibles` feature flag. Production code stayed untouched. Reviewers could focus on new code without worrying about regression in existing flows.
+
+**Logical file grouping.** When a PR touches 80+ files, the diff is unreadable in order. But the files follow a pattern: types in one directory, components in another, queries in a third. Reviewing by directory instead of by diff order makes the structure visible.
+
+**Video demos.** Both PRs included screen recordings showing the before and after. For UI-heavy changes, a video is worth more than any PR description. It answers the reviewer's first question — "does it actually work?" — before they start reading code.
+
+## What I'd do differently
+
+**Ship the type layer first.** The `CollectibleView` type and query hooks could have been a separate PR. It would have been small, easy to review, and established the foundation for the UI work. I underestimated how much easier it is to review large PRs when the data layer is already merged.
+
+**More inline comments on the diff.** For PRs this size, leaving your own review comments on tricky sections saves the reviewer time. "This looks complex but it's just mapping the old Inscription type to the new CollectibleView" is one sentence that saves 10 minutes of confusion.
+
+## The reality
+
+Large PRs are sometimes unavoidable. The goal isn't to never ship them — it's to make them reviewable despite their size. A clear description, a working demo, logical structure, and proactive communication go a long way.
+
+And if your teammate has a meltdown during review, that's just part of the process.

--- a/src/content/blog/spam-token-filtering.md
+++ b/src/content/blog/spam-token-filtering.md
@@ -1,0 +1,43 @@
+---
+title: "Filtering Spam Tokens in a Crypto Wallet"
+description: "A small but important change — detecting and filtering spam token names that contain URLs and scam text in a wallet's asset list."
+pubDate: 2026-02-27
+tags: ["open-source", "crypto", "security", "leather"]
+draft: true
+---
+
+Spam tokens are a real problem in crypto wallets. Scammers airdrop tokens with names like "claim-free-eth.com" or "visit-reward-site.xyz" directly to your address. They show up in your asset list, and if you're not paying attention, you might click through to a phishing site.
+
+The [Leather](https://leather.io) wallet had no defence against this. Whatever name the token contract returned, that's what appeared in the UI. I added a filter in [PR #4113](https://github.com/leather-wallet/extension/pull/4113).
+
+## The approach
+
+The fix is deliberately simple. A utility function checks token names against patterns that indicate spam:
+
+- Does the name contain a URL (http://, https://, or common TLDs)?
+- Does it contain known spam trigger words?
+
+If either check matches, the display name is replaced with "Unknown Token." The actual token data stays intact — you can still see the contract address and interact with it — but the scam name doesn't render in the UI.
+
+```typescript
+// Simplified version of the filter logic
+function filterSpamTokenName(name: string): string {
+  const hasUrl = /https?:\/\/|\.com|\.xyz|\.io/i.test(name);
+  const hasSpamWords = /claim|free|reward|airdrop/i.test(name);
+
+  if (hasUrl || hasSpamWords) return 'Unknown Token';
+  return name;
+}
+```
+
+The function is applied at the display layer — in the crypto currency asset item component — so it doesn't affect any underlying transaction logic or token metadata.
+
+## Testing
+
+The PR includes unit tests covering the edge cases: tokens with URLs in different positions, mixed case, tokens with legitimate names that happen to include common words, and tokens that are clearly clean.
+
+## Why it matters
+
+This is 52 lines of additions across 4 files. It's not a complex architectural change. But it's the kind of defensive UX that users don't notice when it works and absolutely notice when it doesn't — when they see a phishing URL sitting in their asset list pretending to be a token name.
+
+Small PRs can have outsized impact on user trust.


### PR DESCRIPTION
## Summary
- Adds 6 draft blog posts covering open-source contributions at Leather wallet
- Posts cover: mnemonic validation & sign-in redesign, modal routing fixes, full-page container system rebuild, monorepo design, spam token filtering, and shipping large PRs
- All posts set to `draft: true` — won't appear on the live site until published

## Posts
| File | Topic |
|------|-------|
| `mnemonic-validation-wallet-sign-in.md` | Redesigning wallet onboarding with @scure/bip39 |
| `modal-routing-browser-extension.md` | Fixing overlay modal routing in a browser extension |
| `full-page-containers-extension.md` | Replacing the entire container/drawer system |
| `designing-a-monorepo.md` | Monorepo architecture for extension + mobile |
| `spam-token-filtering.md` | Filtering scam token names from asset lists |
| `shipping-monster-prs.md` | Lessons from shipping 5,000+ line PRs |

## Test plan
- [x] `npm run build` passes — drafts are excluded from production output
- [ ] Review each post for accuracy and tone before flipping `draft: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)