### PR TITLE
Blog UX: search, tag filtering, featured section, syntax highlighting

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -4,6 +4,12 @@ import AstroPWA from '@vite-pwa/astro';
 export default defineConfig({
   output: 'static',
   site: 'https://petewatters.ie',
+  markdown: {
+    shikiConfig: {
+      theme: 'github-dark',
+      wrap: true,
+    },
+  },
   integrations: [
     AstroPWA({
       registerType: 'autoUpdate',

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "typescript": "^5.7.0"
       },
       "devDependencies": {
+        "@pagefind/default-ui": "^1.4.0",
         "@playwright/test": "^1.49.0",
         "@typescript-eslint/parser": "^8.55.0",
         "@vite-pwa/astro": "^1.2.0",
@@ -3388,6 +3389,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@oslojs/encoding/-/encoding-1.1.0.tgz",
       "integrity": "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==",
+      "license": "MIT"
+    },
+    "node_modules/@pagefind/default-ui": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@pagefind/default-ui/-/default-ui-1.4.0.tgz",
+      "integrity": "sha512-wie82VWn3cnGEdIjh4YwNESyS1G6vRHwL6cNjy9CFgNnWW/PGRjsLq300xjVH5sfPFK3iK36UxvIBymtQIEiSQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@pkgr/core": {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "scripts": {
     "dev": "astro dev",
-    "build": "astro build",
+    "build": "astro build && npx pagefind --site dist",
     "preview": "astro preview",
     "astro": "astro",
     "check": "astro check",
@@ -22,6 +22,7 @@
     "typescript": "^5.7.0"
   },
   "devDependencies": {
+    "@pagefind/default-ui": "^1.4.0",
     "@playwright/test": "^1.49.0",
     "@typescript-eslint/parser": "^8.55.0",
     "@vite-pwa/astro": "^1.2.0",

--- a/src/components/BlogPostCard.astro
+++ b/src/components/BlogPostCard.astro
@@ -10,7 +10,7 @@ interface Props {
 const { title, description, pubDate, slug, tags } = Astro.props;
 ---
 
-<li class="blog-card">
+<li class="blog-card" data-tags={tags?.join(',')}>
   <time datetime={pubDate.toISOString()}>
     {pubDate.toLocaleDateString('en-IE', { year: 'numeric', month: 'long', day: 'numeric' })}
   </time>
@@ -18,7 +18,7 @@ const { title, description, pubDate, slug, tags } = Astro.props;
   <p>{description}</p>
   {tags && tags.length > 0 && (
     <ul class="tags">
-      {tags.map((tag) => <li>{tag}</li>)}
+      {tags.map((tag) => <li><a href={`#${tag}`} data-filter-tag>{tag}</a></li>)}
     </ul>
   )}
 </li>

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -1,0 +1,7 @@
+<div id="search" data-pagefind-ui></div>
+<link href="/pagefind/pagefind-ui.css" rel="stylesheet" />
+<script>
+  // @ts-ignore — no type declarations for pagefind
+  import { PagefindUI } from '@pagefind/default-ui';
+  new PagefindUI({ element: '#search', showSubResults: true });
+</script>

--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -7,6 +7,7 @@ const blog = defineCollection({
     description: z.string(),
     pubDate: z.coerce.date(),
     tags: z.array(z.string()).default([]),
+    featured: z.boolean().default(false),
     draft: z.boolean().default(false),
   }),
 });

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -17,7 +17,7 @@ const { Content } = await render(post);
 ---
 
 <BaseLayout title={post.data.title} description={post.data.description}>
-  <article class="blog-post">
+  <article class="blog-post" data-pagefind-body>
     <h2>{post.data.title}</h2>
     <time datetime={post.data.pubDate.toISOString()}>
       {post.data.pubDate.toLocaleDateString('en-IE', { year: 'numeric', month: 'long', day: 'numeric' })}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -2,17 +2,50 @@
 import type { CollectionEntry } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import BlogPostCard from '../../components/BlogPostCard.astro';
+import Search from '../../components/Search.astro';
 import { getCollection } from 'astro:content';
 
-const posts = (await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft))
+const allPosts = (await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft))
   .sort((a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
+
+const featuredPosts = allPosts.filter((post: CollectionEntry<'blog'>) => post.data.featured);
+const remainingPosts = allPosts.filter((post: CollectionEntry<'blog'>) => !post.data.featured);
+
+const allTags = [...new Set(allPosts.flatMap((post: CollectionEntry<'blog'>) => post.data.tags))].sort();
 ---
 
 <BaseLayout title="Blog" description="Blog posts by Pete Watters">
   <article>
     <h2>Blog</h2>
+
+    <Search />
+
+    <div class="tag-filters" role="toolbar" aria-label="Filter by tag">
+      <button aria-selected="true" data-tag="all">All</button>
+      {allTags.map((tag) => (
+        <button aria-selected="false" data-tag={tag}>{tag}</button>
+      ))}
+    </div>
+
+    {featuredPosts.length > 0 && (
+      <section class="featured-section">
+        <h3 class="featured-heading">Start Here</h3>
+        <ul class="blog-list">
+          {featuredPosts.map((post: CollectionEntry<'blog'>) => (
+            <BlogPostCard
+              title={post.data.title}
+              description={post.data.description}
+              pubDate={post.data.pubDate}
+              slug={post.id.replace(/\.md$/, '')}
+              tags={post.data.tags}
+            />
+          ))}
+        </ul>
+      </section>
+    )}
+
     <ul class="blog-list">
-      {posts.map((post: CollectionEntry<'blog'>) => (
+      {remainingPosts.map((post: CollectionEntry<'blog'>) => (
         <BlogPostCard
           title={post.data.title}
           description={post.data.description}
@@ -24,3 +57,63 @@ const posts = (await getCollection('blog', ({ data }: CollectionEntry<'blog'>) =
     </ul>
   </article>
 </BaseLayout>
+
+<script>
+  function initTagFilter() {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.tag-filters button');
+    const cards = document.querySelectorAll<HTMLElement>('.blog-card');
+    const featuredSection = document.querySelector<HTMLElement>('.featured-section');
+
+    function filterByTag(tag: string) {
+      buttons.forEach((btn) => btn.setAttribute('aria-selected', String(btn.dataset.tag === tag)));
+
+      if (tag === 'all') {
+        cards.forEach((card) => card.removeAttribute('hidden'));
+        if (featuredSection) featuredSection.removeAttribute('hidden');
+      } else {
+        let anyFeaturedVisible = false;
+        cards.forEach((card) => {
+          const cardTags = card.dataset.tags?.split(',') ?? [];
+          const matches = cardTags.includes(tag);
+          if (matches) {
+            card.removeAttribute('hidden');
+            if (featuredSection?.contains(card)) anyFeaturedVisible = true;
+          } else {
+            card.setAttribute('hidden', '');
+          }
+        });
+        if (featuredSection) {
+          if (anyFeaturedVisible) {
+            featuredSection.removeAttribute('hidden');
+          } else {
+            featuredSection.setAttribute('hidden', '');
+          }
+        }
+      }
+
+      window.history.replaceState(null, '', tag === 'all' ? window.location.pathname : `#${tag}`);
+    }
+
+    buttons.forEach((btn) => {
+      btn.addEventListener('click', () => filterByTag(btn.dataset.tag!));
+    });
+
+    document.addEventListener('click', (e) => {
+      const link = (e.target as HTMLElement).closest<HTMLAnchorElement>('[data-filter-tag]');
+      if (link) {
+        e.preventDefault();
+        const tag = link.textContent?.trim();
+        if (tag) filterByTag(tag);
+      }
+    });
+
+    const hash = window.location.hash.slice(1);
+    if (hash) {
+      const decoded = decodeURIComponent(hash);
+      const matchingBtn = [...buttons].find((b) => b.dataset.tag === decoded);
+      if (matchingBtn) filterByTag(decoded);
+    }
+  }
+
+  initTagFilter();
+</script>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -31,9 +31,12 @@ header a {
 }
 
 :not(pre) > code {
-  font-family: 'Press Start 2P', cursive;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.9em;
   color: white;
-  background-color: grey;
+  background-color: #2B2B2B;
+  padding: 0.15em 0.4em;
+  border-radius: 0.25rem;
 }
 
 pre.astro-code {
@@ -44,7 +47,8 @@ pre.astro-code {
   line-height: 1.6;
 }
 
-pre.astro-code code {
+pre.astro-code code,
+pre.astro-code span {
   font-family: 'Roboto Mono', monospace;
   background: none;
   color: inherit;
@@ -250,6 +254,17 @@ summary {
 
 .blog-post {
   text-align: left;
+}
+
+.blog-post blockquote {
+  border-left: 3px solid #2B2B2B;
+  margin: 1.5rem 0;
+  padding: 0.5rem 1rem;
+  opacity: 0.85;
+}
+
+.blog-post blockquote p {
+  margin: 0;
 }
 
 .blog-post time {

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -30,10 +30,24 @@ header a {
   color: white;
 }
 
-code {
+:not(pre) > code {
   font-family: 'Press Start 2P', cursive;
   color: white;
   background-color: grey;
+}
+
+pre.astro-code {
+  padding: 1rem;
+  border-radius: 0.5rem;
+  overflow-x: auto;
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+
+pre.astro-code code {
+  font-family: 'Roboto Mono', monospace;
+  background: none;
+  color: inherit;
 }
 
 h1 {
@@ -259,6 +273,73 @@ summary {
   color: white;
   padding: 0.2rem 0.6rem;
   border-radius: 0.25rem;
+}
+
+.tags li a {
+  color: white;
+  opacity: 1;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.75rem;
+}
+
+/* Featured section */
+.featured-section {
+  border-bottom: 2px solid #2B2B2B;
+  margin-bottom: 1.5rem;
+  padding-bottom: 0.5rem;
+}
+
+.featured-heading {
+  font-family: 'Permanent Marker', cursive;
+  font-size: 1.2rem;
+  text-align: left;
+}
+
+/* Tag filter pills */
+.tag-filters {
+  display: flex;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: center;
+  margin-bottom: 2rem;
+}
+
+.tag-filters button {
+  background: none;
+  border: 2px solid #2B2B2B;
+  cursor: pointer;
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8rem;
+  padding: 0.3rem 0.8rem;
+  border-radius: 1rem;
+  opacity: 0.5;
+  transition: opacity 0.2s;
+}
+
+.tag-filters button:hover,
+.tag-filters button[aria-selected="true"] {
+  opacity: 1;
+  background: #2B2B2B;
+  color: white;
+}
+
+.blog-card[hidden] {
+  display: none;
+}
+
+.featured-section[hidden] {
+  display: none;
+}
+
+/* Pagefind search overrides */
+.pagefind-ui {
+  --pagefind-ui-font: 'Roboto Mono', monospace;
+  --pagefind-ui-primary: #2B2B2B;
+  --pagefind-ui-background: #fff;
+  --pagefind-ui-border: #2B2B2B;
+  --pagefind-ui-border-width: 2px;
+  --pagefind-ui-border-radius: 0.5rem;
+  margin-bottom: 2rem;
 }
 
 @media screen and (max-width: 42.5rem) {


### PR DESCRIPTION
- Configure Shiki with github-dark theme for code block syntax highlighting
- Add Pagefind search widget to blog listing page
- Add tag filter pill bar with hash-based deep linking and clickable tag labels
- Add featured "Start Here" section with `featured` frontmatter field
- Scope inline code styles so they don't override Shiki themes
- Add `data-pagefind-body` to blog post pages for search indexing
- Pagefind UI styled to match site theme