### PR TITLE
feat: blog as homepage

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,12 +1,7 @@
 ---
 import SocialMedia from './SocialMedia.astro';
-import { ROUTES } from '../consts';
-
-const pathname = Astro.url.pathname.replace(/\/$/, '') || '/';
 ---
 
 <nav>
-  <a href={ROUTES.BLOG} class={pathname.startsWith(ROUTES.BLOG) ? 'active' : ''}>Blog</a>
-  <a href={ROUTES.CV} target="_blank" rel="noopener noreferrer">CV</a>
   <SocialMedia />
 </nav>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -3,8 +3,6 @@ export const SITE_DESCRIPTION = 'Pete Watters Portfolio';
 
 export const ROUTES = {
   HOME: '/',
-  BLOG: '/blog',
-  CV: '/cv',
 } as const;
 
 export const SOCIAL = {

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,13 +1,27 @@
 ---
+import type { CollectionEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import SocialMedia from '../components/SocialMedia.astro';
+import BlogPostCard from '../components/BlogPostCard.astro';
+import { getCollection } from 'astro:content';
+
+const posts = (await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft))
+  .sort((a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf())
+  .slice(0, 5);
 ---
 
 <BaseLayout>
   <article>
-    <p>Full stack developer, UX specialist and JavaScript enthusiast.</p>
-    <footer>
-      <SocialMedia />
-    </footer>
+    <ul class="blog-list">
+      {posts.map((post: CollectionEntry<'blog'>) => (
+        <BlogPostCard
+          title={post.data.title}
+          description={post.data.description}
+          pubDate={post.data.pubDate}
+          slug={post.id.replace(/\.md$/, '')}
+          tags={post.data.tags}
+        />
+      ))}
+    </ul>
+    <a href="/blog">View all posts →</a>
   </article>
 </BaseLayout>

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -7,22 +7,10 @@ test.describe('Navigation', () => {
     await expect(page).toHaveURL('/');
   });
 
-  test('nav links work', async ({ page }) => {
-    await page.goto('/');
-
-    await page.click('nav a[href="/blog"]');
-    await expect(page).toHaveURL('/blog');
-  });
-
   test('404 page renders for unknown routes', async ({ page }) => {
     const response = await page.goto('/nonexistent-page');
     expect(response?.status()).toBe(404);
     await expect(page.locator('h2')).toContainText('404');
     await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
-  });
-
-  test('nav shows active state', async ({ page }) => {
-    await page.goto('/blog');
-    await expect(page.locator('nav a[href="/blog"]')).toHaveClass('active');
   });
 });

--- a/tests/unit/consts.test.ts
+++ b/tests/unit/consts.test.ts
@@ -9,7 +9,6 @@ describe('consts', () => {
 
   it('exports routes', () => {
     expect(ROUTES.HOME).toBe('/');
-    expect(ROUTES.BLOG).toBe('/blog');
   });
 
   it('exports valid social URLs', () => {


### PR DESCRIPTION
## Summary

- Homepage now shows the 5 most recent blog posts with a "View all posts" link to `/blog`
- Nav stripped down to social icons only (removed Blog and CV text links)
- Removed unused `BLOG` and `CV` route constants
- Updated e2e and unit tests to match