### PR TITLE
feat: add 3 new Leather OSS blog posts

### DIFF
--- a/src/content/blog/colour-token-migration.md
+++ b/src/content/blog/colour-token-migration.md
@@ -1,0 +1,71 @@
+---
+title: "Migrating Colour Tokens from Brown to Ink"
+description: "How we renamed an entire design token vocabulary during Leather's rebrand — and why semantic naming matters more than you think."
+pubDate: 2026-03-03
+tags: ["design-systems", "css", "leather"]
+draft: true
+---
+
+When Hiro rebranded its wallet to Leather, we didn't just change a logo. The entire colour system needed to change. The old design tokens were named after literal colours — `brown.100`, `brown.200`, `brown.900` — because the Hiro brand was brown. Leather's brand is black and white. We couldn't just swap hex values and call it done.
+
+## The problem with literal colour names
+
+The old token names encoded the brand colour directly:
+
+```typescript
+// Old tokens
+const colors = {
+  'brown.100': '#F5F1EE',
+  'brown.200': '#ECE0D8',
+  'brown.500': '#74573B',
+  'brown.900': '#2B1D11',
+};
+```
+
+This worked fine when the brand was brown. But now we needed the same semantic scale — light background, subtle border, primary text — in a completely different hue. Renaming `brown.900` to `black.900` would work for the current rebrand but create the same problem for the next one.
+
+## Semantic naming
+
+We renamed the scale to `ink`:
+
+```typescript
+// New tokens
+const colors = {
+  'ink.text-primary': '#0C0C0D',
+  'ink.text-subdued': '#525258',
+  'ink.border-default': '#DFDFE0',
+  'ink.background-primary': '#FFFFFF',
+  'ink.background-secondary': '#F5F5F5',
+};
+```
+
+`ink` is brand-neutral. It describes the role (text, borders, backgrounds) rather than the hue. If Leather rebrands again in two years, the token names stay the same — only the values change.
+
+## The migration
+
+The migration itself was a large find-and-replace across the extension codebase, but it wasn't mindless. We used the rename as an opportunity to audit every colour usage:
+
+| What we found | Action |
+|---|---|
+| Components using `brown.500` for text | Mapped to `ink.text-primary` |
+| Hardcoded hex values that matched brown tokens | Replaced with semantic tokens |
+| One-off colours with no token equivalent | Added to the token set or removed |
+| Dark mode overrides referencing `brown` | Mapped to `ink` equivalents with dark mode values |
+
+The audit caught a dozen places where hex values had been hardcoded instead of using tokens. Those would have broken silently during any theme change.
+
+## The tooling
+
+We updated the design token package (`@leather-wallet/tokens`) to export the new `ink` scale and marked the old `brown` tokens as deprecated. For a transition period, both existed side by side with a build-time warning:
+
+```
+⚠ Deprecated token "brown.500" used in AccountCard.tsx — use "ink.text-primary" instead
+```
+
+This let us migrate incrementally across PRs rather than one enormous changeset. Each component owner could update their own files and verify visually.
+
+## What I'd do differently
+
+I'd start with semantic names from day one. Literal colour names (`red`, `brown`, `blue`) feel intuitive when you first set up a design system, but they become an anchor the moment the brand evolves. Naming tokens by role — `text-primary`, `border-default`, `action-primary` — costs nothing upfront and saves a full migration later.
+
+The Leather rebrand rename touched 40+ files across the extension. The diff was mechanical but the review wasn't — every change needed visual verification. Semantic names would have reduced that to a single token value update.

--- a/src/content/blog/flashlist-vs-flatlist.md
+++ b/src/content/blog/flashlist-vs-flatlist.md
@@ -1,0 +1,66 @@
+---
+title: "FlashList vs FlatList in a Crypto Wallet"
+description: "How switching from FlatList to FlashList cut dropped frames and improved scroll performance in Leather's React Native token list."
+pubDate: 2026-03-03
+tags: ["react-native", "performance", "mobile", "leather"]
+draft: true
+---
+
+The token list in Leather's mobile wallet is the first thing you see when you open the app. It shows every token across multiple chains — BTC, STX, SIP-10 tokens, Runes — sorted by value. When a user has dozens of tokens, that list needs to scroll smoothly.
+
+It didn't.
+
+## The problem
+
+We were using React Native's built-in `FlatList`. For short lists it's fine, but once we added sorting logic and the token count grew past 30-40 items, the scroll started hitching. Dropped frames were visible on mid-range Android devices. The issue was `FlatList`'s recycling strategy — or lack of one.
+
+`FlatList` creates and destroys cell components as they scroll in and out of view. Each mount triggers layout calculation, and for our token cards (which include formatted balances, fiat conversions, and chain icons), that mount cost added up.
+
+## FlashList
+
+[FlashList](https://shopify.github.io/flash-list/) is Shopify's drop-in replacement for `FlatList`. The API is nearly identical — same props, same `renderItem` pattern — but the internals are fundamentally different. FlashList recycles cell components instead of destroying them. When a cell scrolls off screen, its component instance is reused for the next item scrolling in. No unmount, no remount, just new props.
+
+The migration was straightforward:
+
+```tsx
+// Before
+import { FlatList } from 'react-native';
+
+<FlatList
+  data={sortedTokens}
+  renderItem={({ item }) => <TokenCard token={item} />}
+  keyExtractor={(item) => item.id}
+/>
+
+// After
+import { FlashList } from '@shopify/flash-list';
+
+<FlashList
+  data={sortedTokens}
+  renderItem={({ item }) => <TokenCard token={item} />}
+  keyExtractor={(item) => item.id}
+  estimatedItemSize={72}
+/>
+```
+
+The only new required prop is `estimatedItemSize`. FlashList uses it to calculate how many cells to pre-render. Get it roughly right and the list fills the viewport without blank frames on first render.
+
+## Sorting
+
+The same PR also added proper token sorting. Previously tokens appeared in whatever order the API returned them. We sorted by fiat value descending, so the user's most valuable holdings appear first:
+
+```typescript
+const sortedTokens = tokens.sort((a, b) => {
+  const aValue = a.balance * a.fiatPrice;
+  const bValue = b.balance * b.fiatPrice;
+  return bValue - aValue;
+});
+```
+
+Simple, but it matters for UX. Nobody wants to scroll past dust tokens to find their BTC balance.
+
+## The result
+
+FlashList's built-in performance warnings helped us validate the change. With `estimatedItemSize` tuned correctly, the list reported zero blank cells during scroll on both iOS and Android. The dropped frame issue on mid-range Android devices was gone.
+
+The diff was small — a dependency addition, an import swap, and one new prop. The scroll performance improvement was immediately noticeable. If you're using `FlatList` with more than ~20 items and any kind of non-trivial cell rendering, FlashList is worth the five-minute migration.

--- a/src/content/blog/ios-deep-linking.md
+++ b/src/content/blog/ios-deep-linking.md
@@ -1,0 +1,81 @@
+---
+title: "Designing a Mobile Deep Link Flow for iOS"
+description: "Setting up Apple Universal Links for a React Native crypto wallet — associated domains, entitlements, and the apple-app-site-association file."
+pubDate: 2026-03-03
+tags: ["react-native", "ios", "mobile", "leather"]
+draft: true
+---
+
+Deep linking in a mobile app sounds simple. User taps a link, app opens to the right screen. In practice — especially on iOS — it's a minefield of configuration files, entitlements, and Apple-specific behaviour that's poorly documented and painful to debug.
+
+We needed deep links in Leather's mobile wallet so users could tap a payment request URL and land directly on the send screen with the recipient and amount pre-filled. Here's what it took.
+
+## Universal Links vs URL Schemes
+
+iOS supports two kinds of deep links. Custom URL schemes (`leather://send?to=...`) are the old way — they work, but any app can register any scheme, there's no ownership verification, and Safari shows an ugly confirmation dialog. Universal Links (`https://leather.io/send?to=...`) are Apple's preferred approach. They open your app directly with no dialog, and they fall back to the website if the app isn't installed.
+
+Universal Links require more setup, but for a financial app where phishing is a real concern, verified ownership matters. We went with Universal Links.
+
+## The three pieces
+
+### 1. apple-app-site-association
+
+This is a JSON file hosted at `https://yourdomain.com/.well-known/apple-app-site-association`. It tells iOS which URL paths should open your app:
+
+```json
+{
+  "applinks": {
+    "apps": [],
+    "details": [
+      {
+        "appID": "TEAM_ID.io.leather.mobile",
+        "paths": ["/send/*", "/connect/*"]
+      }
+    ]
+  }
+}
+```
+
+Apple's CDN fetches this file when the app is installed (and periodically after). If the file is missing, malformed, or served with the wrong content type, deep links silently fail. No error, no fallback — just nothing happens.
+
+### 2. Associated Domains entitlement
+
+In the Xcode project (or via Expo's `app.json`), you add an Associated Domains entitlement:
+
+```json
+{
+  "expo": {
+    "ios": {
+      "associatedDomains": ["applinks:leather.io"]
+    }
+  }
+}
+```
+
+This gets baked into the app binary at build time. The domain here must exactly match where your `apple-app-site-association` file is hosted.
+
+### 3. Navigation handling
+
+When iOS opens your app via a Universal Link, the URL arrives as a linking event. With React Navigation, you configure a linking config that maps URL paths to screens:
+
+```typescript
+const linking = {
+  prefixes: ['https://leather.io'],
+  config: {
+    screens: {
+      Send: 'send/:address',
+      Connect: 'connect/:session',
+    },
+  },
+};
+```
+
+## What went wrong
+
+Everything, at some point. The associated domains entitlement requires a fresh build — you can't hot-reload it. Apple's CDN caches the `apple-app-site-association` file aggressively, so a fix to the JSON can take hours to propagate. And the best debugging tool — the Apple developer mode link validator — only works in Safari on a Mac signed into the same Apple ID.
+
+The most subtle issue: Universal Links don't work if the user is already in Safari on the same domain. If someone is browsing `leather.io` in Safari and taps a deep link to `leather.io/send/...`, Safari navigates instead of opening the app. Apple considers this "staying in context." You can work around it with a redirect domain or a banner, but it's a UX trap you won't find in the docs.
+
+## The takeaway
+
+Deep linking on iOS is a configuration problem, not a code problem. The actual navigation handling is a few lines. The associated domains, the JSON file, the entitlement, the CDN caching, the debugging — that's where the time goes. Budget a day for setup and testing, not an hour.


### PR DESCRIPTION
## Summary

- **FlashList vs FlatList** — React Native performance post about switching to Shopify's FlashList in the Leather mobile token list (mono/#1202)
- **iOS Deep Linking** — Setting up Apple Universal Links with associated domains for the Leather mobile wallet (mono/#1647)
- **Colour Token Migration** — Renaming design tokens from literal `brown.*` to semantic `ink.*` during the Hiro→Leather rebrand (extension/#4822)

All 3 posts are set to `draft: true` for review before publishing.