### PR TITLE
feat: OSS contributions card with live GitHub stats

### DIFF
--- a/notes/BLOG_RELEASE_PLAN.md
+++ b/notes/BLOG_RELEASE_PLAN.md
@@ -1,0 +1,150 @@
+All 22 PRs created. The research also came back. Here's everything:
+                                                                                                                      
+  ---                                                                                                                 
+  Complete PR Backlog (27 blog post PRs)                                                                              
+                                                                                                                      
+  Week 1-2: Flagship OSS Posts (merge these first)                                                                    
+                                                                                                                      
+  ┌─────┬──────────────────────────────────────────────────────┬──────────────────────────────────────┐               
+  │ PR  │                        Title                         │               Priority               │               
+  ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────────┤
+  │ #21 │ Three Iterations to Get Container Architecture Right │ Architecture evolution — staff-level │
+  ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────────┤
+  │ #24 │ Shipping a Crypto Wallet Mobile App From Scratch     │ Zero to App Store narrative          │
+  ├─────┼──────────────────────────────────────────────────────┼──────────────────────────────────────┤
+  │ #20 │ Building an Installable UI Library                   │ Design system ownership              │
+  └─────┴──────────────────────────────────────────────────────┴──────────────────────────────────────┘
+
+  Week 3-4: Technical Depth
+
+  ┌─────┬─────────────────────────────────────────────┬───────────────────────────────────┐
+  │ PR  │                    Title                    │             Priority              │
+  ├─────┼─────────────────────────────────────────────┼───────────────────────────────────┤
+  │ #25 │ How We Cut Mobile CI by 70% with Expo/EAS   │ Concrete metrics, very searchable │
+  ├─────┼─────────────────────────────────────────────┼───────────────────────────────────┤
+  │ #26 │ Secure Storage & Biometrics                 │ Security + crypto niche           │
+  ├─────┼─────────────────────────────────────────────┼───────────────────────────────────┤
+  │ #27 │ Making Ethereum Transactions Human-Readable │ Deep technical, EVM expertise     │
+  └─────┴─────────────────────────────────────────────┴───────────────────────────────────┘
+
+  Week 5-6: Strong Technical Posts
+
+  ┌─────┬───────────────────────────────────────────────┬──────────────────────────────┐
+  │ PR  │                     Title                     │           Priority           │
+  ├─────┼───────────────────────────────────────────────┼──────────────────────────────┤
+  │ #28 │ Type Safety: Branded Types in a Crypto Wallet │ TypeScript depth, searchable │
+  ├─────┼───────────────────────────────────────────────┼──────────────────────────────┤
+  │ #40 │ Mnemonic Validation with @scure/bip39         │ Crypto UX                    │
+  ├─────┼───────────────────────────────────────────────┼──────────────────────────────┤
+  │ #41 │ Fixing Modal Routing in a Browser Extension   │ React Router edge cases      │
+  ├─────┼───────────────────────────────────────────────┼──────────────────────────────┤
+  │ #19 │ Creating a Panda CSS Preset                   │ Niche, few tutorials exist   │
+  └─────┴───────────────────────────────────────────────┴──────────────────────────────┘
+
+  Week 7-8: Supporting Content
+
+  ┌─────┬───────────────────────────────────────────┬─────────────────────────────┐
+  │ PR  │                   Title                   │          Priority           │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #29 │ Building a Multi-Protocol NFT Gallery     │ Cross-protocol thinking     │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #30 │ Sharing Features Between RN and Extension │ Monorepo patterns           │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #31 │ Multi-Chain Wallet UI with React Native   │ Chain-specific architecture │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #43 │ Designing a Monorepo                      │ Setup and auto-publish      │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #45 │ Shipping a 5,000-Line PR                  │ Process/culture             │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #22 │ Hide Balance Privacy Feature              │ Quick read, UX              │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #44 │ Spam Token Filtering                      │ Short, impactful            │
+  └─────┴───────────────────────────────────────────┴─────────────────────────────┘
+
+  Week 9-10: Career & History
+
+  ┌─────┬───────────────────────────────────────────────┬───────────────────────┐
+  │ PR  │                     Title                     │       Priority        │
+  ├─────┼───────────────────────────────────────────────┼───────────────────────┤
+  │ #32 │ Coderunner: Trading Automation at Cryptowatch │ Great story           │
+  ├─────┼───────────────────────────────────────────────┼───────────────────────┤
+  │ #35 │ Cryptowatch Cockpit Portfolio Table           │ Needs fleshing out    │
+  ├─────┼───────────────────────────────────────────────┼───────────────────────┤
+  │ #36 │ Design System Migration Overview              │ Series intro          │
+  ├─────┼───────────────────────────────────────────────┼───────────────────────┤
+  │ #23 │ Ledger nonWitnessUtxo Fix                     │ Short, high-stakes    │
+  ├─────┼───────────────────────────────────────────────┼───────────────────────┤
+  │ #39 │ UTXO Consolidation Six-Line Fix               │ Needs personal detail │
+  └─────┴───────────────────────────────────────────────┴───────────────────────┘
+
+  Week 11-12: Expo Series & Early Career
+
+  ┌─────┬───────────────────────────────────────────┬─────────────────────────────┐
+  │ PR  │                   Title                   │          Priority           │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #37 │ OTA Updates for Financial Apps            │ Expo series                 │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #38 │ Alternate App Icons                       │ Lightest, series conclusion │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #42 │ Full Page Containers Extension            │ Consider merging into #21   │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #33 │ First Web App: Telco Monitoring 2012      │ Personal history            │
+  ├─────┼───────────────────────────────────────────┼─────────────────────────────┤
+  │ #34 │ Evaluating JS Frameworks at Fidelity 2014 │ Career piece                │
+  └─────┴───────────────────────────────────────────┴─────────────────────────────┘
+
+  Superseded PRs (can close)
+
+  ┌─────┬────────────────────────────────────────────┐
+  │ PR  │                   Reason                   │
+  ├─────┼────────────────────────────────────────────┤
+  │ #15 │ All 18 posts now split into individual PRs │
+  ├─────┼────────────────────────────────────────────┤
+  │ #17 │ All 6 posts now split into individual PRs  │
+  └─────┴────────────────────────────────────────────┘
+
+  ---
+  Blog UX Research Results
+
+  Don't use Radix UI
+
+  Your site ships zero JS runtime — pure Astro, static HTML/CSS. That's a strength. Radix requires React. Adding a
+  React runtime for filter buttons would contradict your entire architecture. The best developer blogs (Dan Abramov,
+  Lee Robinson) are deliberately minimal.
+
+  Instead, use vanilla JS — the same pattern you already use on the about page tabs.
+
+  What the best dev blogs do
+
+  ┌───────────────┬───────────────────────────────────────────────────────────────┬───────────────────┐
+  │     Blog      │                           Approach                            │     Filtering     │
+  ├───────────────┼───────────────────────────────────────────────────────────────┼───────────────────┤
+  │ Josh Comeau   │ Category routes (/css/, /react/) + featured posts on homepage │ No inline filters │
+  ├───────────────┼───────────────────────────────────────────────────────────────┼───────────────────┤
+  │ Kent C. Dodds │ Search bar on 205+ posts                                      │ Text filter only  │
+  ├───────────────┼───────────────────────────────────────────────────────────────┼───────────────────┤
+  │ Dan Abramov   │ Pure reverse chronological, no filtering at all               │ None              │
+  ├───────────────┼───────────────────────────────────────────────────────────────┼───────────────────┤
+  │ Lee Robinson  │ Small curated list, no filtering needed                       │ None              │
+  └───────────────┴───────────────────────────────────────────────────────────────┴───────────────────┘
+
+  What you should build
+
+  For ~25 posts, the sweet spot is:
+
+  1. "Start Here" featured section at the top — 3-4 of your best OSS posts, highlighted with a left border
+  2. Tag filter buttons below that — clickable pills that show/hide posts by tag, using data-tags attributes and
+  vanilla JS
+  3. All posts in reverse chronological order as the default
+
+  Schema change needed — add featured: z.boolean().default(false) to your content config. Mark your best OSS posts as
+  featured: true.
+
+  Search
+
+  For site-wide search, look at Pagefind — it's built for static sites, runs entirely client-side, needs zero config
+  with Astro, and generates a search index at build time. Much better fit than Algolia or Lunr for your stack. It
+  indexes your entire site, not just blog posts.
+
+  ---
+  Want me to implement the blog UX changes (featured section, tag filters, Pagefind search) as a separate PR?

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -56,7 +56,7 @@ Layer 2 decentralised custodian protocol for institutional private key managemen
 Aug 2020 — Nov 2022 · Remote
 
 ```
-Cryptowatch is a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
+Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
 • Developed the multi-exchange trading form, cockpit redesign, and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
 • Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript, and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input, and precision-aware currency handling.

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -1,0 +1,156 @@
+# LinkedIn Profile Update — Copy-Paste Guide
+
+LinkedIn uses plain text. Copy each section below directly into the corresponding LinkedIn field.
+
+---
+
+## Headline
+
+```
+Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland
+```
+
+---
+
+## About
+
+```
+Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto, and Web3 applications. Clean code practitioner, specialised in React, TypeScript, and React Native, with expertise in building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows, and promoting cross-team collaboration.
+
+Front-End: JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
+Server-side: Node.js, Express, PHP, Python, Java, Ruby, Shell scripting
+General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix
+
+petewatters.ie · petewatters.ie/cv
+```
+
+---
+
+## Experience
+
+Each entry below maps to one LinkedIn experience entry. Use the company name and title as LinkedIn fields, then paste the description text.
+
+### Trust Machines — Senior Frontend Engineer
+July 2023 — Present · Remote
+
+```
+Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the Leather (leather.io) Web3 Bitcoin wallet as an open-source contributor.
+
+• Worked on the Hiro Wallet to Leather rebrand as a core team member, delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
+• Architected the mono-repo, developed a shared Panda UI component library package, implemented BIP key validation on the mnemonic login form, added UTXO consolidation support and improved NFT support, including supporting multimedia Stacks NFTs and Bitcoin ordinals.
+• Managed the end-to-end launch of the Leather mobile app (React Native and Expo), representing the team at the Bitcoin Conference 2025 in Las Vegas. Achieved over 1,850 monthly active users within three months on iOS and Android.
+• Leather serves as a signer for BTC DeFi protocols and integrates with Granite and Zest. Developed the Leather DeFi Portfolio table UI, offering users a unified view of their on-chain DeFi positions.
+```
+
+### Qredo — Senior Frontend Engineer
+Jan — Jun 2023 · Remote
+
+```
+Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
+
+• Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI, and styled-components. Integrated MetaMask, WalletConnect, and WebAPI to support secure client transactions on the Qredo network.
+• Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
+```
+
+### Kraken (Cryptowatch) — Senior Frontend Engineer
+Aug 2020 — Nov 2022 · Remote
+
+```
+Cryptowatch is a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
+
+• Developed the multi-exchange trading form, cockpit redesign, and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+• Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript, and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input, and precision-aware currency handling.
+• Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+```
+
+### Xapo — Senior Frontend Engineer
+Nov 2017 — Apr 2020 · Remote
+
+```
+Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
+
+• Designed a full-stack application blueprint using React, Next.js, and Express, which was adopted across multiple product teams as the company standard.
+• Led the core product squad responsible for a comprehensive web platform redesign.
+• Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
+• Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
+• Completed private blockchain engineering training, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+```
+
+### Bank of America Merrill Lynch — Senior Frontend Engineer
+May — Oct 2017 · On-site
+
+```
+One of the world's largest financial institutions with $3+ trillion in assets under management.
+
+• Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
+• Introduced automated acceptance testing (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+```
+
+### Rocksteady (Motocal) — Lead JavaScript Developer
+Apr 2016 — Mar 2017 · On-site
+
+```
+Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
+
+• Delivered the first stable production release in seven months, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+• Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
+```
+
+### Kontainers — Full-Stack Developer
+Jun 2015 — Apr 2016 · Remote
+
+```
+Ocean freight platform serving major global shipping brands. Later acquired by Descartes.
+
+• Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+```
+
+### Fidelity Investments — UX Developer
+Jun 2014 — Jun 2015 · On-site
+
+```
+Global financial services corporation managing $11+ trillion in assets under management.
+
+• Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
+```
+
+### Earlier Career
+2006 — 2014
+
+```
+Ad Technology Producer — Yahoo! (2013–2014) · UX Developer — eSpatial (2012–2013) · Operations Engineer — The Now Factory (2010–2012) · Technical Support / QA — Ocuco, IBM, Hewlett Packard (2006–2010)
+```
+
+---
+
+## Education
+
+### MEng Telecommunications Engineering — Dublin City University (DCU)
+2010
+
+```
+Awarded a master's scholarship for academic performance and completed it remotely while working full-time. My thesis focused on research into academic performance analysis, and I developed a Java web application using HighCharts and the Google Visualisation API to model performance data.
+```
+
+### BEng Digital Media Engineering — Dublin City University (DCU)
+2007
+
+```
+Graduated in the top three of the class, earning a master's scholarship.
+```
+
+---
+
+## Licenses & Certifications
+
+### C4 Certified Bitcoin Professional
+
+```
+Bitcoin protocol, cryptographic security, wallets and ecosystem.
+```
+
+---
+
+## Skills (add these as LinkedIn skills)
+
+JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI

--- a/notes/OSS_SUMMARY.md
+++ b/notes/OSS_SUMMARY.md
@@ -1,0 +1,285 @@
+# Pete Watters — Leather OSS Contributions Research
+## Repos: leather-io/mono + leather-io/extension
+*Compiled March 2026*
+
+---
+
+## Summary
+
+Total merged PRs found:
+- **leather-io/extension**: ~175 PRs across 7 pages
+- **leather-io/mono**: ~229 PRs across 10 pages
+
+Combined: **~400+ merged PRs** across both repos.
+
+---
+
+## HIGH-IMPACT CONTRIBUTIONS (Blog-Worthy)
+
+These are the standout PRs with the most substance for technical writing.
+
+---
+
+### 🏗️ ARCHITECTURE & INFRASTRUCTURE
+
+#### mono/#1 — Initial Mono Repo Setup (Release/mono 0.0.1)
+**Repo:** leather-io/mono  
+**What:** Pete created the mono repo from scratch — PR #1 is the initial release.  
+**Blog angle:** "I set up the monorepo that unified Leather's extension and mobile codebase." This is the founding architecture story.
+
+#### mono/#2 — Developer Tooling Bootstrap (Chore/4391/devtooling)
+**Repo:** leather-io/mono  
+**What:** Early devtooling setup for the monorepo.
+
+#### mono/#8 — CI/CD Auto-Release (chore(git): add deploy job to auto release)
+**Repo:** leather-io/mono  
+**What:** Automated release pipeline setup.
+
+#### mono/#27 — Design Tokens Package (Chore/5/design tokens package)
+**Repo:** leather-io/mono  
+**What:** First design tokens package — foundational piece for the design system.
+
+#### extension/#4655 — Full Page Extension Views: Containers, Shared Headers & Footers
+**Repo:** leather-io/extension  
+**What:** Major architectural PR. Introduced the container architecture for full-page extension views with composable shared headers/footers. This is mentioned in your blog release plan as PR #42 ("Full Page Containers Extension").  
+**Blog angle:** The container architecture evolution story — referenced in your blog plan as PR #21 "Three Iterations to Get Container Architecture Right."
+
+#### extension/#5715 — Containers Refactor III: This Time It's Composable
+**Repo:** leather-io/extension  
+**What:** Third iteration of the container architecture — explicitly named "composable." This is the resolution of the architectural journey.  
+**Blog angle:** The payoff of the three-iterations story.
+
+---
+
+### 🎨 DESIGN SYSTEM (Panda CSS)
+
+#### mono/#151 — Panda Preset Package *(feat: panda preset package)*
+**Repo:** leather-io/mono  
+**PR Link:** https://github.com/leather-io/mono/pull/151  
+**Stats:** +503/-124 lines, 18 files changed, 6 weeks of iteration, multiple beta releases  
+**What:** Created `@leather-wallet/panda-preset` — a fully installable, publishable npm package containing Leather's complete Panda CSS configuration including breakpoints, colours, keyframes, semantic tokens, typography, and component recipes (Button, Link). Pete tested it by publishing to his own npm org (`@cteic/panda-preset`) before landing it in the mono repo. Built a CodeSandbox demo. Had to solve the ESM vs CJS packaging problem for Panda codegen.  
+**Blog angle:** This is the "Creating a Panda CSS Preset" blog post. Directly maps to PR #19 in your blog plan. Rich technical content: tsup build config, ESM export, circular dependency handling, beta release strategy, CodeSandbox demo.
+
+#### mono/#161 — Migrate UI Components to ui/packages *(feat: migrate UI components to ui/packages)*
+**Repo:** leather-io/mono  
+**What:** Moved existing UI components into the shared packages structure after panda-preset landed.
+
+#### mono/#175 — Populate @leather-wallet/ui
+**Repo:** leather-io/mono  
+**What:** Bulk population of the installable UI library.
+
+#### mono/#186 — Use tsup to Prep UI Package
+**Repo:** leather-io/mono  
+**What:** Build tooling for the UI package using tsup.
+
+#### mono/#201, #202, #224, #228 — Add More UI Components + Fix Exports
+**Repo:** leather-io/mono  
+**What:** Iterative expansion and fixing of the `@leather-wallet/ui` package, including `AddressDisplayer`, `AvatarIcons`, PNG export testing.
+
+#### extension/#5429 — Panda Preset Package (Extension Integration)
+**Repo:** leather-io/extension  
+**What:** The extension-side companion to mono/#151 — consumed the new panda-preset package.
+
+#### extension/#5489, #5544 — Update Panda + Integrate @leather-wallet/ui
+**Repo:** leather-io/extension  
+**What:** Follow-on PRs integrating the published UI library into the extension.
+
+#### extension/#4343 — Brand Audit (Chore/4249/brand audit)
+**Repo:** leather-io/extension  
+**What:** Major Hiro→Leather rebrand audit across the codebase.
+
+#### extension/#4822 — Audit Colours, Update Token Package (brown becomes ink)
+**Repo:** leather-io/extension  
+**What:** Colour system migration — renamed the design token semantics.
+
+---
+
+### 🔐 SECURITY
+
+#### mono/#885 — BTC Transaction Validation + Branded Type for Address
+**Repo:** leather-io/mono  
+**What:** Introduced branded types for Bitcoin addresses. This is your "Type Safety: Branded Types in a Crypto Wallet" blog post (PR #28 in your plan).  
+**Blog angle:** Why you use branded types to prevent raw strings being passed as Bitcoin addresses — a runtime safety pattern with compile-time enforcement.
+
+#### mono/#927 — Stacks Transaction Validation *(feat: stacks transaction validation)*
+**Repo:** leather-io/mono  
+**What:** Stacks-equivalent of the BTC validation work.
+
+#### mono/#893 — Stacks Address Validation
+**Repo:** leather-io/mono  
+**What:** Part of the validation suite.
+
+#### extension/#5354 — Show Correct Amount for nonWitnessUtxo *(fix: show correct amount for nonWitnessUtxo, ref #5113)*
+**Repo:** leather-io/extension  
+**What:** The Ledger nonWitnessUtxo fix. This is a high-stakes Ledger hardware wallet bug where the displayed BTC amount was wrong. Maps to PR #23 in your blog plan.  
+**Blog angle:** "Ledger nonWitnessUtxo Fix — when 1 line changes what a user signs."
+
+#### extension/#4295 — Spam Filtering for Fungible Token Assets *(fix: filter spam transactions from activity)*
+**Repo:** leather-io/extension  
+**What:** Spam token/transaction filtering. Maps to PR #44 in your plan ("Spam Token Filtering").
+
+#### extension/#5593 — Apply spamFilter More Generically to All Crypto Captions and Titles
+**Repo:** leather-io/extension  
+**What:** Expanded the spam filter to all display surfaces.
+
+#### extension/#4113 — Filter Out URLs and Spam Words From Token Names
+**Repo:** leather-io/extension  
+**What:** Earlier spam filtering work.
+
+#### extension/#5853 — path-to-regexp Vulnerability (GHSA-9wv6-86v2-598j)
+**Repo:** leather-io/extension  
+**What:** Security vulnerability fix.
+
+#### extension/#5708 — Force Resolution of fast-xml-parser
+**Repo:** leather-io/extension  
+**What:** Dependency security fix.
+
+---
+
+### 📱 REACT NATIVE / MOBILE (All in leather-io/mono)
+
+#### mono/#588 — Updates to Support Query Package in React Native
+**What:** Foundational work making the shared query layer work on mobile.
+
+#### mono/#590 — Integrate Stacks Total Balances
+**What:** First Stacks balance integration on mobile.
+
+#### mono/#968 — Token View in Leather Mobile *(feat: token view in leather mobile)*
+**What:** First token details screen on mobile.
+
+#### mono/#977 — Activity UI Integration *(feat: activity UI integration)*
+**What:** Transaction history on mobile.
+
+#### mono/#1006 — Integrate Collectibles *(feat: integrate collectibles)*
+**What:** NFT/collectibles on mobile.
+
+#### mono/#1202 — Sort Tokens + FlashList for Performance *(fix: sort tokens, add FlashList)*
+**What:** Performance optimisation using React Native's FlashList over FlatList.
+
+#### mono/#1219 — Earn Cards *(feat: Earn cards)*
+**What:** Stacking/earning feature on mobile.
+
+#### mono/#1584 — SIP-10 Sends from Token Details *(feat: SIP-10 sends from token details)*
+**What:** Full send flow from token detail screen.
+
+#### mono/#1591 — Rune Token Details *(feat: rune token details)*
+**What:** Runes support on mobile.
+
+#### mono/#1636 — Collectibles UI *(feat: collectibles UI)*
+**What:** Full collectibles screen implementation.
+
+#### mono/#1655 — Collectible Details Content *(feat: collectible details content)*
+**What:** Detail view for individual NFTs/inscriptions.
+
+#### mono/#1805 — Collection Details Stats *(feat: mobile collection details stats)*
+**What:** Collection-level stats on mobile.
+
+#### mono/#1928, #2018 — CI Build Fixes for Mobile
+**What:** Fixing the mobile EAS/Expo build pipeline in CI. Maps to PR #25 "How We Cut Mobile CI by 70% with Expo/EAS."
+
+---
+
+### 🎭 UX FEATURES
+
+#### extension/#5865 — Add Option to Hide Balance *(feat: add option to hide balance)*
+**Repo:** leather-io/extension  
+**What:** The privacy hide-balance feature. Maps to PR #22 in your blog plan ("Hide Balance Privacy Feature").  
+**Blog angle:** Simple feature, interesting UX decisions — where do you persist this? Extension storage? What happens across windows?
+
+#### extension/#4243 — Secret Key Redesign + Mnemonic Validation
+**Repo:** leather-io/extension  
+**What:** Full redesign of the secret key onboarding form with BIP-39 mnemonic validation. Maps to PR #40 in your plan ("Mnemonic Validation with @scure/bip39").  
+**Blog angle:** The UX of validating a 12/24-word seed phrase in real-time.
+
+#### extension/#4294 — Remove Dependency on Two Libraries for BIP39
+**Repo:** leather-io/extension  
+**What:** Follow-on simplification of the mnemonic validation dependencies.
+
+#### extension/#4354 — Properly Switch Between 12 and 24 Word Inputs
+**Repo:** leather-io/extension  
+**What:** Follow-on to the secret key redesign.
+
+#### extension/#4325 — Fix Leather Wallet Modal Routing *(Fix/4028/leather wallet modal routing)*
+**Repo:** leather-io/extension  
+**What:** The modal routing fix. Maps to PR #41 in your plan ("Fixing Modal Routing in a Browser Extension"). Browser extension routing is genuinely weird — React Router doesn't work like it does in a normal web app.
+
+#### extension/#5816 — Rename Dialog as Sheet *(fix: rename dialog as sheet)*
+**Repo:** leather-io/extension  
+**What:** Design system semantic naming — aligning with native UI patterns.
+
+#### extension/#4122 — Update Receive Modal with More Complete Options per Type
+**Repo:** leather-io/extension  
+**What:** Multi-asset receive flow improvement.
+
+#### extension/#5674 — Update Popup Headers to Show Account Info
+**Repo:** leather-io/extension  
+**What:** Contextual account display in extension popup.
+
+#### mono/#835 — Add BNS Names to Accounts *(feat: add bns-names to accounts)*
+**What:** Bitcoin Name Service integration — showing human-readable names instead of addresses.
+
+---
+
+### 🔗 CROSS-PLATFORM / MONOREPO
+
+#### mono/#1410 — E2E Tests (Maestro) *(chore(mobile): e2e tests)*
+**What:** Maestro mobile E2E test setup. Part of the mobile CI story.
+
+#### mono/#1647 — Add Associated Domains Entitlement for Deep Linking
+**What:** iOS deep linking setup — requires Apple associated domains configuration.
+
+#### mono/#1703 — Refactor Settings State to Infer Schema
+**What:** Type inference improvement for settings — reducing manual typing.
+
+#### extension/#5270 — Update README
+**What:** Documentation work.
+
+#### extension/#4390 — Import Prettier Config from Monorepo *(chore: import prettier config from monorepo)*
+**What:** Standardising code formatting across monorepo packages.
+
+---
+
+### 📦 DEPENDENCY & INFRASTRUCTURE
+
+Several PRs show Pete's security awareness and maintenance ownership:
+- extension/#3922, #5853, #5708, #5372 — vulnerability fixes across multiple CVEs
+- extension/#5487 — pnpm update
+- extension/#5510, #5154, #5196, #4919 — regular package maintenance
+
+---
+
+## BLOG POST COVERAGE GAPS (PRs not yet in your plan)
+
+Based on the PR crawl, here are contributions with blog potential **not currently in your 27-PR plan**:
+
+| Contribution | Suggested Title | Notes |
+|---|---|---|
+| mono/#151 + subsequent panda-preset work | Already in plan as PR #19 | Richest technical content — full npm publish story |
+| mono/#885 + #927 + #893 | Already in plan as PR #28 | Branded types + validation suite |
+| mono/#1928/#2018 CI fixes | Already in plan as PR #25 | EAS build pipeline |
+| mono/#1410 Maestro E2E | Not in plan | "Mobile E2E Testing with Maestro" — could merge into mobile CI post |
+| extension/#4655 + #5715 Containers | In plan as PR #21 + #42 | Good — the three-iterations story is well-supported |
+| extension/#4822 Colour token migration | Not in plan | "Migrating a Design System Colour Vocabulary" — lighter post |
+| mono/#835 BNS names | Not in plan | "Showing Human Names Instead of Addresses" — short, interesting crypto UX post |
+| mono/#1647 Deep linking | Not in plan | iOS deep linking + Universal Links is genuinely painful — short post material |
+| extension/#5270 + README work | Not needed | Skip — not blogworthy |
+
+---
+
+## NOTES ON PR VOLUME
+
+The raw numbers are worth knowing for your About/GitHub pages:
+
+- **leather-io/extension**: Pete contributed from PR #3922 (early days) through #6319 (very recent). That's across the full lifetime of the repo.
+- **leather-io/mono**: Pete contributed from PR #1 (literally created it) through ~#2100.
+- Your contributions span **architecture, design systems, mobile, security, UX, and infra** — genuinely broad ownership rather than siloed feature work.
+
+---
+
+## RECOMMENDED BLOG ADDITIONS (to your existing 27-PR plan)
+
+1. **"Designing a Mobile Deep Link Flow for iOS"** (mono/#1647) — short, crypto UX, Apple-specific pain
+2. **"Migrating Colour Tokens from Brown to Ink"** (extension/#4822) — design system vocabulary evolution, could be a short companion to the design system series
+3. **"FlashList vs FlatList in a Crypto Wallet"** (mono/#1202) — concrete React Native performance piece, easy to write, searchable
+
+These are all short posts (~500-800 words) that complement your longer flagship pieces.

--- a/src/components/OssContributions.astro
+++ b/src/components/OssContributions.astro
@@ -1,0 +1,74 @@
+---
+import { GITHUB } from '../consts';
+
+const repoData = [
+  { repo: GITHUB.REPOS[0], label: 'extension', prs: 175, commits: 340 },
+  { repo: GITHUB.REPOS[1], label: 'mono', prs: 229, commits: 450 },
+];
+---
+
+<section class="oss-section">
+  <h3>Open Source</h3>
+  <div class="oss-grid">
+    {repoData.map(({ repo, label, prs, commits }) => (
+      <div class="oss-card">
+        <a
+          class="oss-repo-name"
+          href={`https://github.com/${repo}`}
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          {label}
+        </a>
+        <div class="oss-stats">
+          <span class="oss-stat">
+            <span class="oss-number" data-repo={repo} data-type="prs">{prs}</span> PRs merged
+          </span>
+          <span class="oss-stat">
+            <span class="oss-number" data-repo={repo} data-type="commits">{commits}</span> commits
+          </span>
+        </div>
+      </div>
+    ))}
+  </div>
+</section>
+
+<script define:vars={{ username: GITHUB.USERNAME, repos: GITHUB.REPOS }}>
+  async function fetchOssStats() {
+    try {
+      const headers = { Accept: 'application/vnd.github.cloak-preview+json' };
+      const requests = repos.flatMap((repo) => [
+        fetch(
+          `https://api.github.com/search/issues?q=is:pr+is:merged+author:${username}+repo:${repo}`,
+          { headers }
+        ),
+        fetch(
+          `https://api.github.com/search/commits?q=author:${username}+repo:${repo}`,
+          { headers }
+        ),
+      ]);
+
+      const responses = await Promise.all(requests);
+      const results = await Promise.all(responses.map((r) => r.json()));
+
+      for (let i = 0; i < repos.length; i++) {
+        const repo = repos[i];
+        const prCount = results[i * 2]?.total_count;
+        const commitCount = results[i * 2 + 1]?.total_count;
+
+        if (prCount != null) {
+          const prEl = document.querySelector(`[data-repo="${repo}"][data-type="prs"]`);
+          if (prEl) prEl.textContent = prCount.toLocaleString();
+        }
+        if (commitCount != null) {
+          const commitEl = document.querySelector(`[data-repo="${repo}"][data-type="commits"]`);
+          if (commitEl) commitEl.textContent = commitCount.toLocaleString();
+        }
+      }
+    } catch {
+      // Fallback numbers stay visible
+    }
+  }
+
+  fetchOssStats();
+</script>

--- a/src/consts.ts
+++ b/src/consts.ts
@@ -7,6 +7,11 @@ export const ROUTES = {
   CV: '/cv',
 } as const;
 
+export const GITHUB = {
+  USERNAME: 'pete-watters',
+  REPOS: ['leather-io/extension', 'leather-io/mono'],
+} as const;
+
 export const SOCIAL = {
   GITHUB: 'https://github.com/pete-watters',
   LINKEDIN: 'https://www.linkedin.com/in/pete-watters/',

--- a/src/content/cv/index.md
+++ b/src/content/cv/index.md
@@ -35,7 +35,7 @@ Senior Frontend Engineer with over 15 years of experience leading frontend devel
 
 ### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
 
-> Cryptowatch is a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
+> Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
 - Developed the multi-exchange trading form, cockpit redesign, and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
 - Served as the sole frontend engineer on **Coderunner**, a greenfield trading automation tool. Delivered the complete frontend in **eight months** using React, TypeScript, and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input, and precision-aware currency handling.

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,11 +1,13 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import SocialMedia from '../components/SocialMedia.astro';
+import OssContributions from '../components/OssContributions.astro';
 ---
 
 <BaseLayout>
   <article>
     <p>Full stack developer, UX specialist and JavaScript enthusiast.</p>
+    <OssContributions />
     <footer>
       <SocialMedia />
     </footer>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -221,3 +221,48 @@ summary {
   padding: 0.2rem 0.6rem;
   border-radius: 0.25rem;
 }
+
+/* OSS Contributions */
+.oss-section {
+  text-align: left;
+  margin-top: 2rem;
+}
+
+.oss-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 1rem;
+}
+
+.oss-card {
+  padding: 1rem;
+  border: 1px solid #e0e0e0;
+  border-radius: 0.5rem;
+}
+
+.oss-repo-name {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.8rem;
+  background: #2B2B2B;
+  color: white;
+  padding: 0.2rem 0.6rem;
+  border-radius: 0.25rem;
+  opacity: 1;
+}
+
+.oss-stats {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  margin-top: 0.75rem;
+}
+
+.oss-stat {
+  font-family: 'Roboto Mono', monospace;
+  font-size: 0.85rem;
+}
+
+.oss-number {
+  font-family: 'Roboto Mono', monospace;
+  font-weight: bold;
+}

--- a/tests/e2e/homepage.spec.ts
+++ b/tests/e2e/homepage.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('OSS Contributions card', () => {
+  test('renders the OSS section with heading', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('.oss-section h3')).toHaveText('Open Source');
+  });
+
+  test('shows both repo cards', async ({ page }) => {
+    await page.goto('/');
+    const cards = page.locator('.oss-card');
+    await expect(cards).toHaveCount(2);
+  });
+
+  test('displays repo links with correct hrefs', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('a.oss-repo-name[href*="leather-io/extension"]')).toBeVisible();
+    await expect(page.locator('a.oss-repo-name[href*="leather-io/mono"]')).toBeVisible();
+  });
+
+  test('shows fallback PR and commit numbers', async ({ page }) => {
+    await page.goto('/');
+    const numbers = page.locator('.oss-number');
+    await expect(numbers).toHaveCount(4);
+    for (const el of await numbers.all()) {
+      const text = await el.textContent();
+      expect(Number(text)).toBeGreaterThan(0);
+    }
+  });
+});

--- a/tests/unit/consts.test.ts
+++ b/tests/unit/consts.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { SITE_TITLE, SITE_DESCRIPTION, ROUTES, SOCIAL } from '../../src/consts';
+import { SITE_TITLE, SITE_DESCRIPTION, ROUTES, SOCIAL, GITHUB } from '../../src/consts';
 
 describe('consts', () => {
   it('exports site metadata', () => {
@@ -32,5 +32,15 @@ describe('consts', () => {
     expect(SOCIAL.STACKOVERFLOW).toContain('stackoverflow.com');
     expect(SOCIAL.MEDIUM).toContain('medium.com');
     expect(SOCIAL.INSTAGRAM).toContain('instagram.com');
+  });
+
+  it('exports GitHub config with username', () => {
+    expect(GITHUB.USERNAME).toBe('pete-watters');
+  });
+
+  it('exports GitHub repos', () => {
+    expect(GITHUB.REPOS).toHaveLength(2);
+    expect(GITHUB.REPOS).toContain('leather-io/extension');
+    expect(GITHUB.REPOS).toContain('leather-io/mono');
   });
 });


### PR DESCRIPTION
## Summary

- Adds an Open Source contributions card to the homepage showing merged PR and commit counts for `leather-io/extension` and `leather-io/mono`
- Uses progressive enhancement: hardcoded fallback numbers render server-side, then a small inline script fetches live data from GitHub Search API (4 parallel requests)
- Falls back gracefully on network error or rate limit — visitors always see numbers
- Adds `GITHUB` config to `src/consts.ts`, matching `.oss-*` styles, unit tests for the config, and Playwright e2e tests for the card