### PR TITLE
chore: add vale prose linter and Cloudflare cache headers

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -1,0 +1,8 @@
+/fonts/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/img/*
+  Cache-Control: public, max-age=31536000, immutable
+
+/_astro/*
+  Cache-Control: public, max-age=31536000, immutable


### PR DESCRIPTION
## Summary
- Add vale prose linter with config and fix blog post language issues
- Add Cloudflare `_headers` file to cache static assets (fonts, images, `/_astro/*`) for 1 year at the edge