### PR TITLE
fix: remove link from Bitcoin cert heading on CV

### DIFF
--- a/src/content/cv/index.md
+++ b/src/content/cv/index.md
@@ -93,6 +93,6 @@ Graduated in the top three of the class, earning a master's scholarship.
 
 ## Certifications
 
-### [C4 Certified Bitcoin Professional](/docs/bitcoin-certified-professional.pdf)
+### C4 Certified Bitcoin Professional
 
 Bitcoin protocol, cryptographic security, wallets and ecosystem.


### PR DESCRIPTION
## Summary
- Converts the C4 Certified Bitcoin Professional heading from a link (pointing to the PDF) to plain text