### PR TITLE
Add Senior Product Engineer CV variant at /cv/product

### DIFF
--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 
@@ -8,12 +8,12 @@ Senior Product Engineer with over 15 years of experience taking products from in
 ## Skills
 
 <dl>
-<dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI</dd>
-<dt>Server-side</dt>
-<dd>Node.js, Express, PHP, Python, Java, Ruby, Shell scripting</dd>
-<dt>General</dt>
-<dd>CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)</dd>
+<dt>Languages & Frameworks</dt>
+<dd>TypeScript, JavaScript, React, React Native, Next.js, Node.js, Express, Redux, Ember.js, Python, Ruby</dd>
+<dt>Web3 & Crypto</dt>
+<dd>Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect</dd>
+<dt>Tooling & Infrastructure</dt>
+<dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)</dd>
 </dl>
 
 ## Work Experience

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,0 +1,99 @@
+---
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+description: "Pete Watters — Senior Product Engineer CV"
+---
+
+Senior Product Engineer with over 15 years of experience taking products from inception to scale across fintech, crypto and Web3. Frontend-first by background — deep React, TypeScript, Next.js and React Native — with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Track record of leading rebrands, greenfield builds and architecture decisions in environments where speed and quality both matter.
+
+## Skills
+
+<dl>
+<dt>Front-End</dt>
+<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI</dd>
+<dt>Server-side</dt>
+<dd>Node.js, Express, PHP, Python, Java, Ruby, Shell scripting</dd>
+<dt>General</dt>
+<dd>CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)</dd>
+</dl>
+
+## Work Experience
+
+### [Trust Machines](https://trustmachines.co) · Senior Frontend Engineer *July 2023 — Present · Remote*
+
+> Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the [Leather](https://leather.io/) Web3 Bitcoin wallet as an open-source contributor.
+
+- Worked on the Hiro Wallet → Leather rebrand end-to-end, delivering a redesigned experience to over **8,400 monthly active extension users** (62,000+ over six months) — owning architecture decisions (first mono-repo, shared Panda UI component library) and security-critical UI work (BIP key validation on mnemonic login).
+- Managed the end-to-end launch of the **Leather mobile app** from scratch using React Native and Expo, growing to over **1,850 monthly active users within three months** on iOS and Android. Represented the team at the **Bitcoin Conference 2025 in Las Vegas**.
+- Shipped the **multi-chain NFT gallery** in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+- Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
+
+### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
+
+> Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
+
+- Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
+- Developed a **Node.js ETH transaction parser** to present on-chain history in a human-readable format, improving compliance and operational transparency.
+
+### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
+
+> Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
+
+- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+- Owned the frontend for **Coderunner**, a greenfield trading automation tool, as sole frontend engineer working directly with product and a backend partner. Delivered to a polished MVP in **eight months** using React, TypeScript and PostCSS — including a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
+- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+
+### [Xapo](https://www.xapo.com) · Senior Frontend Engineer *Nov 2017 — Apr 2020 · Remote*
+
+> Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
+
+- Designed the **React, Next.js and Express full-stack application blueprint** adopted across multiple product teams as Xapo's engineering standard — making the architectural decisions that shaped how the company shipped product.
+- Led the core product squad responsible for a comprehensive web platform redesign.
+- Built **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and accelerating release cycles.
+- Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
+- Completed **private blockchain engineering training**, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+
+### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Senior Frontend Engineer *May — Oct 2017 · On-site*
+
+> One of the world's largest financial institutions with $3+ trillion in assets under management.
+
+- Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
+- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+
+### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer *Apr 2016 — Mar 2017 · On-site*
+
+> Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
+
+- Delivered the **first stable production release in seven months**, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
+
+### Kontainers · Full-Stack Developer *Jun 2015 — Apr 2016 · Remote*
+
+> Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
+
+- Recruited by the co-founder and CTO to lead the frontend product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+
+### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
+
+> Global financial services corporation managing $11+ trillion in assets under management.
+
+- Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during **Enterprise Ireland R&D accreditation**.
+
+### Earlier Career *2006 — 2014*
+
+Ad Technology Producer — Yahoo! (2013–2014) · UX Developer — eSpatial (2012–2013) · Operations Engineer — The Now Factory (2010–2012) · Technical Support / QA — Ocuco, IBM, Hewlett Packard (2006–2010)
+
+## Education
+
+### MEng Telecommunications Engineering · Dublin City University (DCU) · 2010
+
+Awarded a master's scholarship for academic performance and completed it remotely while working full-time. [My thesis](/docs/thesis-pete-watters.pdf) focused on research into academic performance analysis. I developed a Java web application using HighCharts and the Google Visualisation API to model performance data.
+
+### BEng Digital Media Engineering · Dublin City University (DCU) · 2007
+
+Graduated in the top three of the class, earning a master's scholarship.
+
+## Certifications
+
+### C4 Certified Bitcoin Professional
+
+Bitcoin protocol, cryptographic security, wallets and ecosystem.


### PR DESCRIPTION
Stacked on #59. Adds a third CV variant at `/cv/product` derived from the Senior Frontend Engineer CV — same role history, dates and achievements, reframed positioning.

## What changed (vs `frontend.md`)
| Section | Reframed |
|---|---|
| Tagline | `Senior Frontend Engineer` → `Senior Product Engineer` |
| Description meta | matches |
| Summary | "frontend development for high-traffic apps" → "taking products from inception to scale… frontend-first by background with full-stack range and product judgment to own features end-to-end" |
| Trust Machines rebrand bullet | now leads with user outcome (8,400 MAU), frames architecture and security-critical UI as ownership |
| Cryptowatch Coderunner bullet | opens "Owned the frontend… working directly with product and a backend partner"; deliverable reframed as polished MVP |
| Xapo blueprint bullet | emphasises "architectural decisions that shaped how the company shipped product" |

## What did NOT change
Skills, Qredo, BAML, Rocksteady, Kontainers, Fidelity, Earlier Career, Education, Certifications — exactly as in `frontend.md`. No new bullets, no new claims.

## Three judgement calls flagged
1. **"Led" → "Worked on"** for the rebrand opener. Spec said "Led the Hiro Wallet → Leather rebrand end-to-end", but you corrected me one PR ago that you didn't lead the rebrand. Defaulted to the accurate version. The reframed bullet still reads naturally with "Worked on" because the ownership detail comes after.
2. **Spec typos** silently fixed: `"over 1of experience"` → `"over 15 years of experience"`; `"delivering a erience"` → `"delivering a redesigned experience"`; `"custom dynamicgeneration"` → `"custom dynamic form-generation"` (matches the source bullet).
3. **File slug** is `product.md` → `/cv/product` to match the existing `frontend` / `full-stack` naming pattern.

Build + typecheck clean. No new tests added — the existing dynamic-route tests cover route mechanics and the two pre-existing variants.