### PR TITLE
Sync LinkedIn + GitHub README; align all CV taglines on Node.js

### DIFF
--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -1,6 +1,6 @@
 # Pete Watters
 
-**Senior Frontend Engineer** — Bitcoin, Web3, and high-stakes fintech.
+**Senior Frontend Engineer** — Bitcoin, Web3 and high-stakes fintech.
 
 Currently at [Trust Machines](https://trustmachines.co), building [Leather](https://leather.io) — the leading wallet for Bitcoin and Stacks apps. Open-source contributor to the [Leather mono-repo](https://github.com/leather-io/mono).
 
@@ -8,22 +8,23 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 **Leather Wallet** — Bitcoin & Stacks wallet serving 8,400+ monthly active extension users
 
-- Core team on the Hiro Wallet to Leather rebrand — architected the mono-repo, built the shared Panda UI component library, implemented BIP key validation
-- Shipped the first **Leather mobile app** (React Native + Expo), growing to 1,850+ MAU in three months
-- Built the DeFi Portfolio UI for on-chain position tracking across Granite and Zest
+- Core team on the Hiro Wallet → Leather rebrand — architected the mono-repo, built the shared Panda UI component library, implemented BIP key validation on the mnemonic login form
+- Shipped the **Leather mobile app** from scratch (React Native + Expo), growing to 1,850+ MAU in three months on iOS and Android
+- Shipped the **multi-chain NFT gallery** (Stacks SIP-9 + Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow
+- Early AI-tooling adopter on the team — established working patterns with Claude Code and Codex, contributed to CLAUDE.md and reusable skills
 
 ## Notable open-source contributions
 
-**Monorepo architecture for Leather wallet** — Designed the mono-repo that consolidated the browser extension, mobile app, and shared packages into a single repository with automated npm publishing.
+**Monorepo architecture for Leather wallet** — Designed the mono-repo that consolidated the browser extension, mobile app and shared packages into a single repository with automated npm publishing.
 [leather-wallet/mono#8](https://github.com/leather-wallet/mono/pull/8)
 
 **Mnemonic validation on wallet sign-in** — Replaced a single textarea with word-by-word input and real-time BIP-39 validation using `@scure/bip39`. 739 additions across 27 files including new E2E tests.
 [leather-wallet/extension#4243](https://github.com/leather-wallet/extension/pull/4243)
 
-**Full-page container system rebuild** — Replaced the entire drawer and container system with Radix Dialog, unified headers, and standardised viewport widths. ~100 files, 8 bugs fixed.
+**Full-page container system rebuild** — Replaced the entire drawer and container system with Radix Dialog, unified headers and standardised viewport widths. ~100 files, 8 bugs fixed.
 [leather-wallet/extension#4655](https://github.com/leather-wallet/extension/pull/4655)
 
-**Modal routing refactor** — Fixed overlay modal routing to properly handle background content, direct navigation, and nested route state in the browser extension.
+**Modal routing refactor** — Fixed overlay modal routing to properly handle background content, direct navigation and nested route state in the browser extension.
 [leather-wallet/extension#4325](https://github.com/leather-wallet/extension/pull/4325)
 
 **Spam token filtering** — Added detection and filtering of scam token names containing URLs and phishing text in the wallet's asset list.
@@ -34,8 +35,8 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 ## Tech
 
-**Frontend:** React, TypeScript, Next.js, React Native, Expo, Redux, Ember.js
-**Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD
+**Frontend:** TypeScript, React, Next.js, React Native, Expo, Redux, Ember.js
+**Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD, AI-assisted development (Claude Code, Codex)
 **Server-side:** Node.js, Express, Python, Ruby
 
 ## Previously
@@ -49,6 +50,6 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 ## Links
 
 - [petewatters.ie](https://petewatters.ie) — Portfolio & blog
-- [petewatters.ie/cv](https://petewatters.ie/cv) — CV
+- [petewatters.ie/cv/frontend](https://petewatters.ie/cv/frontend) — CV
 - [LinkedIn](https://www.linkedin.com/in/pete-watters/)
 - [StackOverflow](https://stackoverflow.com/users/1365580/peadar)

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -2,12 +2,14 @@
 
 LinkedIn uses plain text. Copy each section below directly into the corresponding LinkedIn field.
 
+Mirrors the Senior Frontend Engineer CV variant at `src/content/cv/frontend.md`. When that file changes, update this one too.
+
 ---
 
 ## Headline
 
 ```
-Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland
+Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland
 ```
 
 ---
@@ -15,13 +17,13 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native 
 ## About
 
 ```
-Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto, and Web3 applications. Clean code practitioner, specialised in React, TypeScript, and React Native, with expertise in building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows, and promoting cross-team collaboration.
+Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto and Web3 applications. Clean code practitioner specialised in React, TypeScript and Next.js, with deep React Native experience and a focus on building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows and promoting cross-team collaboration.
 
-Front-End: JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
+Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, PHP, Python, Java, Ruby, Shell scripting
-General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix
+General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)
 
-petewatters.ie · petewatters.ie/cv
+petewatters.ie · petewatters.ie/cv/frontend
 ```
 
 ---
@@ -36,10 +38,10 @@ July 2023 — Present · Remote
 ```
 Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the Leather (leather.io) Web3 Bitcoin wallet as an open-source contributor.
 
-• Worked on the Hiro Wallet to Leather rebrand as a core team member, delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
-• Architected the mono-repo, developed a shared Panda UI component library package, implemented BIP key validation on the mnemonic login form, added UTXO consolidation support and improved NFT support, including supporting multimedia Stacks NFTs and Bitcoin ordinals.
-• Managed the end-to-end launch of the Leather mobile app (React Native and Expo), representing the team at the Bitcoin Conference 2025 in Las Vegas. Achieved over 1,850 monthly active users within three months on iOS and Android.
-• Leather serves as a signer for BTC DeFi protocols and integrates with Granite and Zest. Developed the Leather DeFi Portfolio table UI, offering users a unified view of their on-chain DeFi positions.
+• Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
+• Managed the end-to-end launch of the Leather mobile app from scratch using React Native and Expo, growing to over 1,850 monthly active users within three months on iOS and Android. Represented the team at the Bitcoin Conference 2025 in Las Vegas.
+• Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+• Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 ```
 
 ### Qredo — Senior Frontend Engineer
@@ -48,7 +50,7 @@ Jan — Jun 2023 · Remote
 ```
 Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
-• Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI, and styled-components. Integrated MetaMask, WalletConnect, and WebAPI to support secure client transactions on the Qredo network.
+• Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
 • Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 ```
 
@@ -58,8 +60,8 @@ Aug 2020 — Nov 2022 · Remote
 ```
 Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
-• Developed the multi-exchange trading form, cockpit redesign, and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
-• Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript, and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input, and precision-aware currency handling.
+• Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+• Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
 • Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
 ```
 
@@ -69,7 +71,7 @@ Nov 2017 — Apr 2020 · Remote
 ```
 Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
 
-• Designed a full-stack application blueprint using React, Next.js, and Express, which was adopted across multiple product teams as the company standard.
+• Designed a React, Next.js and Express full-stack application blueprint, adopted across multiple product teams as the company standard.
 • Led the core product squad responsible for a comprehensive web platform redesign.
 • Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
 • Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
@@ -153,4 +155,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI
+TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
+tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland"
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland"
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 


### PR DESCRIPTION
Stacked on #60. Two related changes.

## 1. Tagline alignment — Node.js across all variants
- `frontend.md` and `product.md` taglines now read `… React / TypeScript / Node.js …` (was `React Native`).
- `full-stack.md` already used Node.js — unchanged.
- React Native still surfaced in skills lists and relevant work bullets.

## 2. Sync LinkedIn + GitHub README to current frontend CV
Both files were sitting on pre-#56 / pre-#58 / pre-#59 content. Pulled them up to mirror `src/content/cv/frontend.md`.

**LinkedIn (`notes/LINKEDIN_UPDATE.md`)**
- Headline / About / Summary text matches frontend CV
- Skills rows reordered (TypeScript first, Next.js promoted)
- General row gains `AI-assisted development (Claude Code, Codex)`
- Trust Machines reduced to the same 4 bullets — drops the legacy DeFi portfolio / Granite / Zest content
- LinkedIn skills tag list gains `Claude Code, Codex`
- Oxford commas stripped
- Header note added pointing at `frontend.md` as the source of truth

**GitHub README (`GITHUB_PROFILE_README.md`)**
- Intro: `Bitcoin, Web3 and high-stakes fintech` (Oxford comma dropped)
- "What I'm working on" reduced from 3 bullets to 4 mirroring the new TM section (rebrand, mobile from scratch, NFT gallery + AI workflow, AI-tooling adopter) — drops the DeFi portfolio bullet
- Tech list: TypeScript first; AI-assisted dev added to Tooling
- OSS contributions section: Oxford commas stripped (descriptions otherwise unchanged)

## Notes
- CV deep-link in both files now points at `/cv/frontend` specifically, since `/cv` redirects to the full-stack default. If you'd rather they go through `/cv` and let the redirect handle it, easy revert.
- I positioned both files around the **Senior Frontend Engineer** variant since that's their existing framing. Tell me if you want LinkedIn / README repositioned around the Product Engineer or Software Engineer variant — that's a bigger call than "consistency".
- Build + all 15 CV e2e tests pass.