### PR TITLE
Bring product variant + LinkedIn/README sync + skills restructure into main

### DIFF
--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -1,6 +1,6 @@
 # Pete Watters
 
-**Senior Frontend Engineer** — Bitcoin, Web3, and high-stakes fintech.
+**Senior Frontend Engineer** — Bitcoin, Web3 and high-stakes fintech.
 
 Currently at [Trust Machines](https://trustmachines.co), building [Leather](https://leather.io) — the leading wallet for Bitcoin and Stacks apps. Open-source contributor to the [Leather mono-repo](https://github.com/leather-io/mono).
 
@@ -8,22 +8,23 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 **Leather Wallet** — Bitcoin & Stacks wallet serving 8,400+ monthly active extension users
 
-- Core team on the Hiro Wallet to Leather rebrand — architected the mono-repo, built the shared Panda UI component library, implemented BIP key validation
-- Shipped the first **Leather mobile app** (React Native + Expo), growing to 1,850+ MAU in three months
-- Built the DeFi Portfolio UI for on-chain position tracking across Granite and Zest
+- Core team on the Hiro Wallet → Leather rebrand — architected the mono-repo, built the shared Panda UI component library, implemented BIP key validation on the mnemonic login form
+- Shipped the **Leather mobile app** from scratch (React Native + Expo), growing to 1,850+ MAU in three months on iOS and Android
+- Shipped the **multi-chain NFT gallery** (Stacks SIP-9 + Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow
+- Early AI-tooling adopter on the team — established working patterns with Claude Code and Codex, contributed to CLAUDE.md and reusable skills
 
 ## Notable open-source contributions
 
-**Monorepo architecture for Leather wallet** — Designed the mono-repo that consolidated the browser extension, mobile app, and shared packages into a single repository with automated npm publishing.
+**Monorepo architecture for Leather wallet** — Designed the mono-repo that consolidated the browser extension, mobile app and shared packages into a single repository with automated npm publishing.
 [leather-wallet/mono#8](https://github.com/leather-wallet/mono/pull/8)
 
 **Mnemonic validation on wallet sign-in** — Replaced a single textarea with word-by-word input and real-time BIP-39 validation using `@scure/bip39`. 739 additions across 27 files including new E2E tests.
 [leather-wallet/extension#4243](https://github.com/leather-wallet/extension/pull/4243)
 
-**Full-page container system rebuild** — Replaced the entire drawer and container system with Radix Dialog, unified headers, and standardised viewport widths. ~100 files, 8 bugs fixed.
+**Full-page container system rebuild** — Replaced the entire drawer and container system with Radix Dialog, unified headers and standardised viewport widths. ~100 files, 8 bugs fixed.
 [leather-wallet/extension#4655](https://github.com/leather-wallet/extension/pull/4655)
 
-**Modal routing refactor** — Fixed overlay modal routing to properly handle background content, direct navigation, and nested route state in the browser extension.
+**Modal routing refactor** — Fixed overlay modal routing to properly handle background content, direct navigation and nested route state in the browser extension.
 [leather-wallet/extension#4325](https://github.com/leather-wallet/extension/pull/4325)
 
 **Spam token filtering** — Added detection and filtering of scam token names containing URLs and phishing text in the wallet's asset list.
@@ -34,8 +35,8 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 ## Tech
 
-**Frontend:** React, TypeScript, Next.js, React Native, Expo, Redux, Ember.js
-**Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD
+**Frontend:** TypeScript, React, Next.js, React Native, Expo, Redux, Ember.js
+**Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD, AI-assisted development (Claude Code, Codex)
 **Server-side:** Node.js, Express, Python, Ruby
 
 ## Previously
@@ -49,6 +50,6 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 ## Links
 
 - [petewatters.ie](https://petewatters.ie) — Portfolio & blog
-- [petewatters.ie/cv](https://petewatters.ie/cv) — CV
+- [petewatters.ie/cv/frontend](https://petewatters.ie/cv/frontend) — CV
 - [LinkedIn](https://www.linkedin.com/in/pete-watters/)
 - [StackOverflow](https://stackoverflow.com/users/1365580/peadar)

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -2,12 +2,14 @@
 
 LinkedIn uses plain text. Copy each section below directly into the corresponding LinkedIn field.
 
+Mirrors the Senior Frontend Engineer CV variant at `src/content/cv/frontend.md`. When that file changes, update this one too.
+
 ---
 
 ## Headline
 
 ```
-Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland
+Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland
 ```
 
 ---
@@ -15,13 +17,13 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native 
 ## About
 
 ```
-Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto, and Web3 applications. Clean code practitioner, specialised in React, TypeScript, and React Native, with expertise in building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows, and promoting cross-team collaboration.
+Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto and Web3 applications. Clean code practitioner specialised in React, TypeScript and Next.js, with deep React Native experience and a focus on building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows and promoting cross-team collaboration.
 
-Front-End: JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
+Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, PHP, Python, Java, Ruby, Shell scripting
-General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix
+General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)
 
-petewatters.ie · petewatters.ie/cv
+petewatters.ie · petewatters.ie/cv/frontend
 ```
 
 ---
@@ -36,10 +38,10 @@ July 2023 — Present · Remote
 ```
 Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the Leather (leather.io) Web3 Bitcoin wallet as an open-source contributor.
 
-• Worked on the Hiro Wallet to Leather rebrand as a core team member, delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
-• Architected the mono-repo, developed a shared Panda UI component library package, implemented BIP key validation on the mnemonic login form, added UTXO consolidation support and improved NFT support, including supporting multimedia Stacks NFTs and Bitcoin ordinals.
-• Managed the end-to-end launch of the Leather mobile app (React Native and Expo), representing the team at the Bitcoin Conference 2025 in Las Vegas. Achieved over 1,850 monthly active users within three months on iOS and Android.
-• Leather serves as a signer for BTC DeFi protocols and integrates with Granite and Zest. Developed the Leather DeFi Portfolio table UI, offering users a unified view of their on-chain DeFi positions.
+• Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
+• Managed the end-to-end launch of the Leather mobile app from scratch using React Native and Expo, growing to over 1,850 monthly active users within three months on iOS and Android. Represented the team at the Bitcoin Conference 2025 in Las Vegas.
+• Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+• Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 ```
 
 ### Qredo — Senior Frontend Engineer
@@ -48,7 +50,7 @@ Jan — Jun 2023 · Remote
 ```
 Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
-• Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI, and styled-components. Integrated MetaMask, WalletConnect, and WebAPI to support secure client transactions on the Qredo network.
+• Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
 • Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 ```
 
@@ -58,8 +60,8 @@ Aug 2020 — Nov 2022 · Remote
 ```
 Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
-• Developed the multi-exchange trading form, cockpit redesign, and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
-• Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript, and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input, and precision-aware currency handling.
+• Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+• Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
 • Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
 ```
 
@@ -69,7 +71,7 @@ Nov 2017 — Apr 2020 · Remote
 ```
 Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
 
-• Designed a full-stack application blueprint using React, Next.js, and Express, which was adopted across multiple product teams as the company standard.
+• Designed a React, Next.js and Express full-stack application blueprint, adopted across multiple product teams as the company standard.
 • Led the core product squad responsible for a comprehensive web platform redesign.
 • Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
 • Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
@@ -153,4 +155,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-JavaScript, TypeScript, React, React Native, Next.js, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI
+TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -9,11 +9,13 @@ Senior Frontend Engineer with over 15 years of experience leading frontend devel
 
 <dl>
 <dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI</dd>
+<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Panda CSS, Radix UI</dd>
 <dt>Server-side</dt>
-<dd>Node.js, Express, PHP, Python, Java, Ruby, Shell scripting</dd>
-<dt>General</dt>
-<dd>CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)</dd>
+<dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
+<dt>Web3 & Crypto</dt>
+<dd>Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect</dd>
+<dt>Tooling</dt>
+<dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)</dd>
 </dl>
 
 ## Work Experience

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
+tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland"
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -8,12 +8,14 @@ Senior Software Engineer with over 15 years of experience delivering full-stack 
 ## Skills
 
 <dl>
-<dt>Languages & Frameworks</dt>
-<dd>TypeScript, JavaScript, React, React Native, Next.js, Node.js, Express, Redux, Ember.js, Python, Ruby</dd>
+<dt>Front-End</dt>
+<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux</dd>
+<dt>Server-side</dt>
+<dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
 <dt>Web3 & Crypto</dt>
 <dd>Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect</dd>
-<dt>Tooling & Infrastructure</dt>
-<dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix</dd>
+<dt>Tooling</dt>
+<dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)</dd>
 </dl>
 
 ## Work Experience

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -8,11 +8,13 @@ Senior Product Engineer with over 15 years of experience taking products from in
 ## Skills
 
 <dl>
-<dt>Languages & Frameworks</dt>
-<dd>TypeScript, JavaScript, React, React Native, Next.js, Node.js, Express, Redux, Ember.js, Python, Ruby</dd>
+<dt>Front-End</dt>
+<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux</dd>
+<dt>Server-side</dt>
+<dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
 <dt>Web3 & Crypto</dt>
 <dd>Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect</dd>
-<dt>Tooling & Infrastructure</dt>
+<dt>Tooling</dt>
 <dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)</dd>
 </dl>
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 
@@ -8,12 +8,12 @@ Senior Product Engineer with over 15 years of experience taking products from in
 ## Skills
 
 <dl>
-<dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI</dd>
-<dt>Server-side</dt>
-<dd>Node.js, Express, PHP, Python, Java, Ruby, Shell scripting</dd>
-<dt>General</dt>
-<dd>CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)</dd>
+<dt>Languages & Frameworks</dt>
+<dd>TypeScript, JavaScript, React, React Native, Next.js, Node.js, Express, Redux, Ember.js, Python, Ruby</dd>
+<dt>Web3 & Crypto</dt>
+<dd>Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect</dd>
+<dt>Tooling & Infrastructure</dt>
+<dd>CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)</dd>
 </dl>
 
 ## Work Experience

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,5 +1,5 @@
 ---
-tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / React Native · Dublin, Ireland"
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland"
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -1,0 +1,99 @@
+---
+tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Next.js · Dublin, Ireland"
+description: "Pete Watters — Senior Product Engineer CV"
+---
+
+Senior Product Engineer with over 15 years of experience taking products from inception to scale across fintech, crypto and Web3. Frontend-first by background — deep React, TypeScript, Next.js and React Native — with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Track record of leading rebrands, greenfield builds and architecture decisions in environments where speed and quality both matter.
+
+## Skills
+
+<dl>
+<dt>Front-End</dt>
+<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI</dd>
+<dt>Server-side</dt>
+<dd>Node.js, Express, PHP, Python, Java, Ruby, Shell scripting</dd>
+<dt>General</dt>
+<dd>CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)</dd>
+</dl>
+
+## Work Experience
+
+### [Trust Machines](https://trustmachines.co) · Senior Frontend Engineer *July 2023 — Present · Remote*
+
+> Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the [Leather](https://leather.io/) Web3 Bitcoin wallet as an open-source contributor.
+
+- Worked on the Hiro Wallet → Leather rebrand end-to-end, delivering a redesigned experience to over **8,400 monthly active extension users** (62,000+ over six months) — owning architecture decisions (first mono-repo, shared Panda UI component library) and security-critical UI work (BIP key validation on mnemonic login).
+- Managed the end-to-end launch of the **Leather mobile app** from scratch using React Native and Expo, growing to over **1,850 monthly active users within three months** on iOS and Android. Represented the team at the **Bitcoin Conference 2025 in Las Vegas**.
+- Shipped the **multi-chain NFT gallery** in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+- Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
+
+### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
+
+> Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
+
+- Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
+- Developed a **Node.js ETH transaction parser** to present on-chain history in a human-readable format, improving compliance and operational transparency.
+
+### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
+
+> Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
+
+- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+- Owned the frontend for **Coderunner**, a greenfield trading automation tool, as sole frontend engineer working directly with product and a backend partner. Delivered to a polished MVP in **eight months** using React, TypeScript and PostCSS — including a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
+- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+
+### [Xapo](https://www.xapo.com) · Senior Frontend Engineer *Nov 2017 — Apr 2020 · Remote*
+
+> Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
+
+- Designed the **React, Next.js and Express full-stack application blueprint** adopted across multiple product teams as Xapo's engineering standard — making the architectural decisions that shaped how the company shipped product.
+- Led the core product squad responsible for a comprehensive web platform redesign.
+- Built **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and accelerating release cycles.
+- Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
+- Completed **private blockchain engineering training**, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+
+### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Senior Frontend Engineer *May — Oct 2017 · On-site*
+
+> One of the world's largest financial institutions with $3+ trillion in assets under management.
+
+- Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
+- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+
+### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer *Apr 2016 — Mar 2017 · On-site*
+
+> Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
+
+- Delivered the **first stable production release in seven months**, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
+
+### Kontainers · Full-Stack Developer *Jun 2015 — Apr 2016 · Remote*
+
+> Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
+
+- Recruited by the co-founder and CTO to lead the frontend product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+
+### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
+
+> Global financial services corporation managing $11+ trillion in assets under management.
+
+- Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during **Enterprise Ireland R&D accreditation**.
+
+### Earlier Career *2006 — 2014*
+
+Ad Technology Producer — Yahoo! (2013–2014) · UX Developer — eSpatial (2012–2013) · Operations Engineer — The Now Factory (2010–2012) · Technical Support / QA — Ocuco, IBM, Hewlett Packard (2006–2010)
+
+## Education
+
+### MEng Telecommunications Engineering · Dublin City University (DCU) · 2010
+
+Awarded a master's scholarship for academic performance and completed it remotely while working full-time. [My thesis](/docs/thesis-pete-watters.pdf) focused on research into academic performance analysis. I developed a Java web application using HighCharts and the Google Visualisation API to model performance data.
+
+### BEng Digital Media Engineering · Dublin City University (DCU) · 2007
+
+Graduated in the top three of the class, earning a master's scholarship.
+
+## Certifications
+
+### C4 Certified Bitcoin Professional
+
+Bitcoin protocol, cryptographic security, wallets and ecosystem.

--- a/tests/e2e/cv.spec.ts
+++ b/tests/e2e/cv.spec.ts
@@ -17,10 +17,10 @@ test.describe('CV page', () => {
       await expect(page.locator('.cv')).toContainText('Senior Software Engineer');
     });
 
-    test('displays skills section with full-stack groupings', async ({ page }) => {
+    test('displays skills section with frontend groupings', async ({ page }) => {
       await page.goto('/cv/full-stack');
       await expect(page.locator('dl')).toBeVisible();
-      await expect(page.locator('dt').first()).toContainText('Languages & Frameworks');
+      await expect(page.locator('dt').first()).toContainText('Front-End');
     });
 
     test('displays work experience', async ({ page }) => {


### PR DESCRIPTION
**Originally** scoped as just the skills 4-row restructure, but PRs #60 and #61 were merged into stacked branches rather than into `main`. Retargeting this PR to `main` brings the full backlog forward in a single merge.

## What's included (5 commits)

1. **`feat(cv): add Senior Product Engineer variant at /cv/product`** (was #60)
   - New `src/content/cv/product.md` derived from the frontend variant; routes to `/cv/product`.

2. **`fix(cv): drop Next.js from taglines; migrate product variant to current skills structure`** (was part of #60 follow-up)
   - Removes `Next.js` from frontend + product taglines.
   - Migrates the product variant's skills to the Languages & Frameworks / Web3 & Crypto / Tooling & Infrastructure structure that full-stack used.

3. **`fix(cv): use Node.js (not React Native) in all variant taglines`** (was part of #61)
   - frontend.md and product.md taglines now match full-stack: `… React / TypeScript / Node.js …`.

4. **`chore: sync LinkedIn and GitHub README templates with frontend CV`** (was #61)
   - `notes/LINKEDIN_UPDATE.md` and `GITHUB_PROFILE_README.md` updated to mirror the latest frontend CV (Trust Machines bullets, skills ordering, AI tooling, Oxford commas stripped, CV deep-link → `/cv/frontend`).

5. **`feat(cv): unify skills section across variants on a 4-row structure`** (the original #62 commit)
   - All three CV variants share the same row labels — Front-End / Server-side / Web3 & Crypto / Tooling — with content weighted per variant.
   - Drops PHP, Java, Ember.js, CasperJS, `.io` suffix on Cypress from skills lists (Ember.js / CasperJS retained in role bullets where historically accurate).

Build + 15 e2e CV tests pass on the tip.