### PR TITLE
Refresh CV summaries, prose-ify single-bullet roles, strip inline bold; resync LinkedIn + README

### DIFF
--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -9,8 +9,8 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 **Leather Wallet** — Bitcoin & Stacks wallet serving 8,400+ monthly active extension users
 
 - Core team on the Hiro Wallet → Leather rebrand — architected the mono-repo, built the shared Panda UI component library, implemented BIP key validation on the mnemonic login form
-- Shipped the **Leather mobile app** from scratch (React Native + Expo), growing to 1,850+ MAU in three months on iOS and Android
-- Shipped the **multi-chain NFT gallery** (Stacks SIP-9 + Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow
+- Shipped the Leather mobile app from scratch (React Native + Expo), growing to 1,850+ MAU in three months on iOS and Android
+- Shipped the multi-chain NFT gallery (Stacks SIP-9 + Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow
 - Early AI-tooling adopter on the team — established working patterns with Claude Code and Codex, contributed to CLAUDE.md and reusable skills
 
 ## Notable open-source contributions
@@ -35,7 +35,7 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 ## Tech
 
-**Frontend:** TypeScript, React, Next.js, React Native, Expo, Redux, Ember.js
+**Frontend:** TypeScript, React, Next.js, React Native, Expo, Redux
 **Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD, AI-assisted development (Claude Code, Codex)
 **Server-side:** Node.js, Express, Python, Ruby
 

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -17,11 +17,12 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto and Web3 applications. Clean code practitioner specialised in React, TypeScript and Next.js, with deep React Native experience and a focus on building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows and promoting cross-team collaboration.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Specialises in React, TypeScript and Next.js, with deep React Native experience and a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
-Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Panda CSS, Radix UI
-Server-side: Node.js, Express, PHP, Python, Java, Ruby, Shell scripting
-General: CI/CD, TDD, Cucumber, Cypress.io, Playwright, Maestro, CasperJS, Git, Unix, AI-assisted development (Claude Code, Codex)
+Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Panda CSS, Radix UI
+Server-side: Node.js, Express, Python, Ruby, Shell scripting
+Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect
+Tooling: CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)
 
 petewatters.ie · petewatters.ie/cv/frontend
 ```
@@ -155,4 +156,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-TypeScript, React, Next.js, React Native, JavaScript, Redux, Ember.js, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex
+TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -3,7 +3,7 @@ tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 
-Senior Frontend Engineer with over 15 years of experience leading frontend development for high-traffic fintech, crypto and Web3 applications. Clean code practitioner specialised in React, TypeScript and Next.js, with deep React Native experience and a focus on building scalable, user-focused solutions. Demonstrated success in major product launches, optimising engineering workflows and promoting cross-team collaboration.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Specialises in React, TypeScript and Next.js, with deep React Native experience and a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
 ## Skills
 
@@ -24,9 +24,9 @@ Senior Frontend Engineer with over 15 years of experience leading frontend devel
 
 > Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the [Leather](https://leather.io/) Web3 Bitcoin wallet as an open-source contributor.
 
-- Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over **8,400 monthly active extension users** (62,000+ over six months).
-- Managed the end-to-end launch of the **Leather mobile app** from scratch using React Native and Expo, growing to over **1,850 monthly active users within three months** on iOS and Android. Represented the team at the **Bitcoin Conference 2025 in Las Vegas**.
-- Shipped the **multi-chain NFT gallery** in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+- Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
+- Managed the end-to-end launch of the Leather mobile app from scratch using React Native and Expo, growing to over 1,850 monthly active users within three months on iOS and Android. Represented the team at the Bitcoin Conference 2025 in Las Vegas.
+- Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
 - Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 
 ### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
@@ -34,51 +34,51 @@ Senior Frontend Engineer with over 15 years of experience leading frontend devel
 > Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
 - Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
-- Developed a **Node.js ETH transaction parser** to present on-chain history in a human-readable format, improving compliance and operational transparency.
+- Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 
 ### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
 
 > Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
-- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
-- Served as the sole frontend engineer on **Coderunner**, a greenfield trading automation tool. Delivered the complete frontend in **eight months** using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
-- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+- Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
+- Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
 
 ### [Xapo](https://www.xapo.com) · Senior Frontend Engineer *Nov 2017 — Apr 2020 · Remote*
 
 > Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
 
-- Designed a **React, Next.js and Express full-stack application blueprint**, adopted across multiple product teams as the company standard.
+- Designed a React, Next.js and Express full-stack application blueprint, adopted across multiple product teams as the company standard.
 - Led the core product squad responsible for a comprehensive web platform redesign.
-- Built **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and accelerating release cycles.
+- Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
 - Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
-- Completed **private blockchain engineering training**, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+- Completed private blockchain engineering training, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
 
 ### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Senior Frontend Engineer *May — Oct 2017 · On-site*
 
 > One of the world's largest financial institutions with $3+ trillion in assets under management.
 
 - Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
-- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+- Introduced automated acceptance testing (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
 
 ### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer *Apr 2016 — Mar 2017 · On-site*
 
 > Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
 
-- Delivered the **first stable production release in seven months**, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Delivered the first stable production release in seven months, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
 - Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
 
 ### Kontainers · Full-Stack Developer *Jun 2015 — Apr 2016 · Remote*
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-- Recruited by the co-founder and CTO to lead the frontend product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-- Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during **Enterprise Ireland R&D accreditation**.
+Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -3,7 +3,7 @@ tagline: "Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Software Engineer CV"
 ---
 
-Senior Software Engineer with over 15 years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3. Deep expertise in React, TypeScript and React Native, with hands-on experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Demonstrated success in major product launches, optimising engineering workflows and promoting cross-team collaboration.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
 ## Skills
 
@@ -24,9 +24,9 @@ Senior Software Engineer with over 15 years of experience delivering full-stack 
 
 > Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the [Leather](https://leather.io/) Web3 Bitcoin wallet as an open-source contributor.
 
-- Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over **8,400 monthly active extension users** (62,000+ over six months).
-- Managed the end-to-end launch of the **Leather mobile app** from scratch using React Native and Expo, growing to over **1,850 monthly active users within three months** on iOS and Android. Represented the team at the **Bitcoin Conference 2025 in Las Vegas**.
-- Shipped the **multi-chain NFT gallery** in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+- Worked on the Hiro Wallet → Leather rebrand as a core team member — architected the mono-repo, built a shared Panda UI component library and implemented BIP key validation on the mnemonic login form — delivering a redesigned experience for over 8,400 monthly active extension users (62,000+ over six months).
+- Managed the end-to-end launch of the Leather mobile app from scratch using React Native and Expo, growing to over 1,850 monthly active users within three months on iOS and Android. Represented the team at the Bitcoin Conference 2025 in Las Vegas.
+- Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
 - Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 
 ### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
@@ -34,51 +34,51 @@ Senior Software Engineer with over 15 years of experience delivering full-stack 
 > Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
 - Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
-- Developed a **Node.js ETH transaction parser** to present on-chain history in a human-readable format, improving compliance and operational transparency.
+- Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 
 ### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
 
 > Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
-- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
-- Served as the sole frontend engineer on **Coderunner**, a greenfield trading automation tool. Delivered the complete frontend in **eight months** using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
-- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+- Served as the sole frontend engineer on Coderunner, a greenfield trading automation tool. Delivered the complete frontend in eight months using React, TypeScript and PostCSS with a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
+- Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
 
 ### [Xapo](https://www.xapo.com) · Senior Frontend Engineer *Nov 2017 — Apr 2020 · Remote*
 
 > Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
 
-- Designed a **full-stack application blueprint** — React, Next.js and Express — adopted as the company standard across multiple product teams.
+- Designed a full-stack application blueprint — React, Next.js and Express — adopted as the company standard across multiple product teams.
 - Led the core product squad responsible for a comprehensive web platform redesign.
-- Built **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and accelerating release cycles.
+- Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
 - Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
-- Completed **private blockchain engineering training**, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+- Completed private blockchain engineering training, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
 
 ### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Senior Frontend Engineer *May — Oct 2017 · On-site*
 
 > One of the world's largest financial institutions with $3+ trillion in assets under management.
 
 - Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
-- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+- Introduced automated acceptance testing (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
 
 ### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer *Apr 2016 — Mar 2017 · On-site*
 
 > Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
 
-- Delivered the **first stable production release in seven months**, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Delivered the first stable production release in seven months, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
 - Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
 
 ### Kontainers · Full-Stack Developer *Jun 2015 — Apr 2016 · Remote*
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-- Recruited by the co-founder and CTO to lead the frontend product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-- Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during **Enterprise Ireland R&D accreditation**.
+Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 


### PR DESCRIPTION
Single PR off `main`, no stack.

## CV changes (all three variants — frontend, full-stack, product)

**Inline bold stripped** from all bullet body text. Section headers, role titles and company names retain their bold (per the spec).

**Kontainers + Fidelity** — single-bullet roles converted to prose paragraphs across all three variants. Text content unchanged.

**Summaries refreshed** on frontend and full-stack only — product summary intentionally left as-is, since that variant's positioning shouldn't be aligned to the other two.

- **Frontend Engineer:** "Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Specialises in React, TypeScript and Next.js, with deep React Native experience and a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter."
- **Software Engineer:** "Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter."

## Template sync

The CV update from PR #62 (4-row skills structure dropping PHP / Java / Ember.js / Cypress.io / CasperJS) hadn't been propagated to LinkedIn yet — this PR closes that drift.

- **`notes/LINKEDIN_UPDATE.md`:** summary updated to match new frontend CV; About-block skills restructured to Front-End / Server-side / Web3 & Crypto / Tooling matching the CVs; Ember.js dropped from the LinkedIn skills tag list at the bottom.
- **`GITHUB_PROFILE_README.md`:** Ember.js dropped from Tech > Frontend; inline bold stripped from "What I'm working on" bullets.

## What did NOT change
- LinkedIn experience entries kept as bullets (LinkedIn convention) rather than collapsing single-bullet entries to prose.
- All role bullets, dates, role titles, section headers untouched besides the targeted bold/prose changes.
- product.md summary left as the standalone Product Engineer framing.

Build + 15 e2e CV tests pass.