### PR TITLE
Bring 4 post-#63-merge commits into main: product formatting + frontend summary + Kontainers/Fidelity copy + drop JavaScript

### DIFF
--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -1,6 +1,6 @@
 # Pete Watters
 
-**Senior Frontend Engineer** — Bitcoin, Web3 and high-stakes fintech.
+**Senior Software Engineer** — Bitcoin, Web3 and high-stakes fintech.
 
 Currently at [Trust Machines](https://trustmachines.co), building [Leather](https://leather.io) — the leading wallet for Bitcoin and Stacks apps. Open-source contributor to the [Leather mono-repo](https://github.com/leather-io/mono).
 
@@ -35,9 +35,10 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 ## Tech
 
-**Frontend:** TypeScript, React, Next.js, React Native, Expo, Redux
-**Tooling:** Panda CSS, Radix UI, Playwright, Cypress, Vitest, CI/CD, AI-assisted development (Claude Code, Codex)
-**Server-side:** Node.js, Express, Python, Ruby
+**Front-End:** TypeScript, React, Next.js, React Native, Expo, Redux, HTML5, CSS3, Panda CSS, Radix UI
+**Server-side:** Node.js, Express, Python, Ruby, Shell scripting
+**Web3 & Crypto:** Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect, Wagmi
+**Tooling:** CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, AI-assisted development (Claude Code, Codex)
 
 ## Previously
 
@@ -50,6 +51,6 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 ## Links
 
 - [petewatters.ie](https://petewatters.ie) — Portfolio & blog
-- [petewatters.ie/cv/frontend](https://petewatters.ie/cv/frontend) — CV
+- [petewatters.ie/cv/full-stack](https://petewatters.ie/cv/full-stack) — CV
 - [LinkedIn](https://www.linkedin.com/in/pete-watters/)
 - [StackOverflow](https://stackoverflow.com/users/1365580/peadar)

--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -37,7 +37,7 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 **Front-End:** TypeScript, React, Next.js, React Native, Expo, Redux, HTML5, CSS3, Panda CSS, Radix UI
 **Server-side:** Node.js, Express, Python, Ruby, Shell scripting
-**Web3 & Crypto:** Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect, Wagmi
+**Web3 & Crypto:** Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect
 **Tooling:** CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, AI-assisted development (Claude Code, Codex)
 
 ## Previously

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -19,7 +19,7 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ```
 Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
-Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Panda CSS, Radix UI
+Front-End: TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting
 Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect
 Tooling: CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)
@@ -156,4 +156,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex
+TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -105,7 +105,7 @@ Jun 2015 — Apr 2016 · Remote
 ```
 Ocean freight platform serving major global shipping brands. Later acquired by Descartes.
 
-• Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+• Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD).
 ```
 
 ### Fidelity Investments — UX Developer
@@ -114,7 +114,7 @@ Jun 2014 — Jun 2015 · On-site
 ```
 Global financial services corporation managing $11+ trillion in assets under management.
 
-• Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
+• Responsible for building prototype fintech applications. Technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 ```
 
 ### Earlier Career

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -17,7 +17,7 @@ Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3. Deep expertise in React, TypeScript, Next.js and React Native, with hands-on experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3. Deep expertise in React, TypeScript, Next.js and React Native, with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 Currently building the Leather Bitcoin wallet at Trust Machines — an open-source Web3 wallet serving 60,000+ users across browser extension and mobile. Previously at Kraken/Cryptowatch, Xapo, Qredo and Fidelity.
 
@@ -25,7 +25,7 @@ Specialised in crypto product engineering: wallet architecture, DeFi integration
 
 Front-End: TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting
-Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect, Wagmi
+Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect
 Tooling: CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, AI-assisted development (Claude Code, Codex)
 
 petewatters.ie · petewatters.ie/cv/full-stack
@@ -160,4 +160,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Bitcoin, Stacks, MetaMask, WalletConnect, Wagmi, Claude Code, Codex
+TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Bitcoin, Stacks, MetaMask, WalletConnect, Claude Code, Codex

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -17,7 +17,7 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
 
 Front-End: TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -17,7 +17,7 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 Front-End: TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -2,14 +2,14 @@
 
 LinkedIn uses plain text. Copy each section below directly into the corresponding LinkedIn field.
 
-Mirrors the Senior Frontend Engineer CV variant at `src/content/cv/frontend.md`. When that file changes, update this one too.
+Mirrors the Senior Software Engineer CV variant at `src/content/cv/full-stack.md`. When that file changes, update this one too.
 
 ---
 
 ## Headline
 
 ```
-Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland
+Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Dublin, Ireland
 ```
 
 ---
@@ -17,14 +17,18 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3. Deep expertise in React, TypeScript, Next.js and React Native, with hands-on experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+
+Currently building the Leather Bitcoin wallet at Trust Machines — an open-source Web3 wallet serving 60,000+ users across browser extension and mobile. Previously at Kraken/Cryptowatch, Xapo, Qredo and Fidelity.
+
+Specialised in crypto product engineering: wallet architecture, DeFi integrations, trading interfaces, design systems and cross-platform mobile. C4 Certified Bitcoin Professional.
 
 Front-End: TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting
-Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect
-Tooling: CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, Cucumber, Unix, AI-assisted development (Claude Code, Codex)
+Web3 & Crypto: Bitcoin, Stacks, sBTC, wallet integration, MetaMask, WalletConnect, Wagmi
+Tooling: CI/CD, Docker, Git, Cypress, Playwright, Maestro, Vitest, TDD, AI-assisted development (Claude Code, Codex)
 
-petewatters.ie · petewatters.ie/cv/frontend
+petewatters.ie · petewatters.ie/cv/full-stack
 ```
 
 ---
@@ -156,4 +160,4 @@ Bitcoin protocol, cryptographic security, wallets and ecosystem.
 
 ## Skills (add these as LinkedIn skills)
 
-TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Claude Code, Codex
+TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Node.js, Express, Python, CI/CD, TDD, Cypress, Playwright, Git, Panda CSS, Radix UI, Bitcoin, Stacks, MetaMask, WalletConnect, Wagmi, Claude Code, Codex

--- a/notes/LINKEDIN_UPDATE.md
+++ b/notes/LINKEDIN_UPDATE.md
@@ -17,7 +17,7 @@ Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Node.js · Du
 ## About
 
 ```
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Specialises in React, TypeScript and Next.js, with deep React Native experience and a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
 Front-End: TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Panda CSS, Radix UI
 Server-side: Node.js, Express, Python, Ruby, Shell scripting

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -3,7 +3,7 @@ tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -9,7 +9,7 @@ Senior Frontend Engineer with 15+ years of experience across fintech, crypto and
 
 <dl>
 <dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux, HTML5, CSS3, Panda CSS, Radix UI</dd>
+<dd>TypeScript, React, Next.js, React Native, Redux, HTML5, CSS3, Panda CSS, Radix UI</dd>
 <dt>Server-side</dt>
 <dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
 <dt>Web3 & Crypto</dt>

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -3,7 +3,7 @@ tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
 
 ## Skills
 

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -3,7 +3,7 @@ tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Specialises in React, TypeScript and Next.js, with deep React Native experience and a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
 
 ## Skills
 

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -72,13 +72,13 @@ Senior Frontend Engineer with 15+ years of experience across fintech, crypto and
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD).
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
+Responsible for building prototype fintech applications. Technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 

--- a/src/content/cv/frontend.md
+++ b/src/content/cv/frontend.md
@@ -3,7 +3,7 @@ tagline: "Senior Frontend Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Frontend Engineer CV"
 ---
 
-Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
+Senior Frontend Engineer with 15+ years of experience across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Deep expertise in React, TypeScript, Next.js and React Native, with a track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -3,7 +3,7 @@ tagline: "Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Software Engineer CV"
 ---
 
-Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -3,7 +3,7 @@ tagline: "Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Software Engineer CV"
 ---
 
-Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3. Deep expertise in React, TypeScript, Next.js and React Native, with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -9,7 +9,7 @@ Senior Software Engineer with 15+ years of experience delivering full-stack web 
 
 <dl>
 <dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux</dd>
+<dd>TypeScript, React, Next.js, React Native, Redux</dd>
 <dt>Server-side</dt>
 <dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
 <dt>Web3 & Crypto</dt>

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -72,13 +72,13 @@ Senior Software Engineer with 15+ years of experience delivering full-stack web 
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD).
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
+Responsible for building prototype fintech applications. Technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 

--- a/src/content/cv/full-stack.md
+++ b/src/content/cv/full-stack.md
@@ -3,7 +3,7 @@ tagline: "Senior Software Engineer · Bitcoin & Web3 · React / TypeScript / Nod
 description: "Pete Watters — Senior Software Engineer CV"
 ---
 
-Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Track record of leading product launches, design systems and architecture decisions in high-stakes environments where security, performance and user trust matter.
+Senior Software Engineer with 15+ years of experience delivering full-stack web and mobile applications across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with hands-on production experience across the stack — Node.js, Express, CI/CD, architecture and developer tooling. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
 
 ## Skills
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -72,13 +72,13 @@ Senior Product Engineer with over 15 years of experience taking products from in
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD).
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
+Responsible for building prototype fintech applications. Technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -3,7 +3,7 @@ tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Node
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 
-Senior Product Engineer with 15+ years of experience taking products from inception to scale across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
+Senior Product Engineer with 15+ years of experience taking products from inception to scale across fintech, crypto and Web3. Frontend-first by background (React, TypeScript, Next.js, React Native) with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -3,7 +3,7 @@ tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Node
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 
-Senior Product Engineer with 15+ years of experience taking products from inception to scale across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
+Senior Product Engineer with 15+ years of experience taking products from inception to scale across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Custodian of engineering quality, with a clear sense of what matters most — shipping products people use.
 
 ## Skills
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -3,7 +3,7 @@ tagline: "Senior Product Engineer · Bitcoin & Web3 · React / TypeScript / Node
 description: "Pete Watters — Senior Product Engineer CV"
 ---
 
-Senior Product Engineer with over 15 years of experience taking products from inception to scale across fintech, crypto and Web3. Frontend-first by background — deep React, TypeScript, Next.js and React Native — with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Track record of leading rebrands, greenfield builds and architecture decisions in environments where speed and quality both matter.
+Senior Product Engineer with 15+ years of experience taking products from inception to scale across fintech, crypto and Web3 — most recently building the Leather Bitcoin wallet at Trust Machines. Frontend-first by background (React, TypeScript, Next.js, React Native) with the full-stack range and product judgment to own features end-to-end, ship quickly and stay close to the user. Custodian of engineering quality, with a clear sense of what matters most — shipping products users actually use.
 
 ## Skills
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -24,9 +24,9 @@ Senior Product Engineer with over 15 years of experience taking products from in
 
 > Contribute to the largest ecosystem of Bitcoin applications on the Stacks network. Actively maintain and enhance the [Leather](https://leather.io/) Web3 Bitcoin wallet as an open-source contributor.
 
-- Worked on the Hiro Wallet → Leather rebrand end-to-end, delivering a redesigned experience to over **8,400 monthly active extension users** (62,000+ over six months) — owning architecture decisions (first mono-repo, shared Panda UI component library) and security-critical UI work (BIP key validation on mnemonic login).
-- Managed the end-to-end launch of the **Leather mobile app** from scratch using React Native and Expo, growing to over **1,850 monthly active users within three months** on iOS and Android. Represented the team at the **Bitcoin Conference 2025 in Las Vegas**.
-- Shipped the **multi-chain NFT gallery** in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
+- Worked on the Hiro Wallet → Leather rebrand end-to-end, delivering a redesigned experience to over 8,400 monthly active extension users (62,000+ over six months) — owning architecture decisions (first mono-repo, shared Panda UI component library) and security-critical UI work (BIP key validation on mnemonic login).
+- Managed the end-to-end launch of the Leather mobile app from scratch using React Native and Expo, growing to over 1,850 monthly active users within three months on iOS and Android. Represented the team at the Bitcoin Conference 2025 in Las Vegas.
+- Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
 - Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 
 ### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
@@ -34,51 +34,51 @@ Senior Product Engineer with over 15 years of experience taking products from in
 > Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
 - Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
-- Developed a **Node.js ETH transaction parser** to present on-chain history in a human-readable format, improving compliance and operational transparency.
+- Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 
 ### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*
 
 > Cryptowatch was a widely used real-time charting and trading terminal in the crypto community, acquired by Kraken and later integrated into Kraken Pro. Supported millions of active traders across 25 exchanges and over 4,000 markets.
 
-- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the **Cryptowatch trading team**. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
-- Owned the frontend for **Coderunner**, a greenfield trading automation tool, as sole frontend engineer working directly with product and a backend partner. Delivered to a polished MVP in **eight months** using React, TypeScript and PostCSS — including a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
-- Initiated a **Cypress E2E testing framework** for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
+- Developed the multi-exchange trading form, cockpit redesign and custom trade table and leverage slider components for the Cryptowatch trading team. Built high-traffic, mission-critical infrastructure with direct visibility to executive leadership.
+- Owned the frontend for Coderunner, a greenfield trading automation tool, as sole frontend engineer working directly with product and a backend partner. Delivered to a polished MVP in eight months using React, TypeScript and PostCSS — including a custom dynamic form-generation system supporting consistent field types such as market picker, asset-aware amount input and precision-aware currency handling.
+- Initiated a Cypress E2E testing framework for Cryptowatch as a side project. Won the company-wide Codebashing security challenge in 2020, placing first for expertise in client-side vulnerabilities and OWASP mitigations.
 
 ### [Xapo](https://www.xapo.com) · Senior Frontend Engineer *Nov 2017 — Apr 2020 · Remote*
 
 > Fully remote global FinTech providing multi-currency digital wallets and Bitcoin custody services, serving over 1.5 million customers worldwide.
 
-- Designed the **React, Next.js and Express full-stack application blueprint** adopted across multiple product teams as Xapo's engineering standard — making the architectural decisions that shaped how the company shipped product.
+- Designed the React, Next.js and Express full-stack application blueprint adopted across multiple product teams as Xapo's engineering standard — making the architectural decisions that shaped how the company shipped product.
 - Led the core product squad responsible for a comprehensive web platform redesign.
-- Built **CI/CD infrastructure and E2E testing standards** from the ground up, reducing manual QA overhead and accelerating release cycles.
+- Built CI/CD infrastructure and E2E testing standards from the ground up, reducing manual QA overhead and accelerating release cycles.
 - Mentored engineers on testing practices and architecture patterns. Served as a technical bar-raiser during hiring across the engineering organisation and developed the hiring process.
-- Completed **private blockchain engineering training**, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
+- Completed private blockchain engineering training, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song.
 
 ### [Bank of America Merrill Lynch](https://www.bankofamerica.com) · Senior Frontend Engineer *May — Oct 2017 · On-site*
 
 > One of the world's largest financial institutions with $3+ trillion in assets under management.
 
 - Served as the Ember.js subject-matter expert and senior frontend engineer within a team of six, working across the stack with Python and Django to deliver investment performance tracking software.
-- Introduced **automated acceptance testing** (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
+- Introduced automated acceptance testing (TDD/BDD with Cucumber) to the BAML frontend workflow, establishing it as the team standard. Mentored the team and delivered a series of technical presentations to elevate team quality standards.
 
 ### [Motocal](https://www.motocal.com/) · Rocksteady · Lead JavaScript Developer *Apr 2016 — Mar 2017 · On-site*
 
 > Web-based tool for custom decal manufacturing. Recruited to recover a failing legacy Ember.js and Fabric.js application.
 
-- Delivered the **first stable production release in seven months**, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
+- Delivered the first stable production release in seven months, reducing test cycle time by 70%. Designed and implemented CI/CD with automated E2E testing (Docker, Webdriver.io, CasperJS) and automated deployment using Gitflow and custom Bash scripts.
 - Recruited and onboarded a team of two to replace the outgoing engineering team, reporting directly to the CEO and CTO.
 
 ### Kontainers · Full-Stack Developer *Jun 2015 — Apr 2016 · Remote*
 
 > Ocean freight platform serving major global shipping brands. Later acquired by [Descartes](https://www.descartes.com/resources/news/descartes-acquires-kontainers).
 
-- Recruited by the co-founder and CTO to lead the frontend product from **inception to production** (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
+Recruited by the co-founder and CTO to lead the frontend product from inception to production (JavaScript, Ember.js, Ruby, CI/CD), establishing the engineering culture at the seed stage.
 
 ### [Fidelity Investments](https://www.fidelity.com) · UX Developer *Jun 2014 — Jun 2015 · On-site*
 
 > Global financial services corporation managing $11+ trillion in assets under management.
 
-- Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during **Enterprise Ireland R&D accreditation**.
+Served as technical lead for an offshore development team, providing hands-on direction in the UK and India. Represented the engineering team during Enterprise Ireland R&D accreditation.
 
 ### Earlier Career *2006 — 2014*
 

--- a/src/content/cv/product.md
+++ b/src/content/cv/product.md
@@ -9,7 +9,7 @@ Senior Product Engineer with over 15 years of experience taking products from in
 
 <dl>
 <dt>Front-End</dt>
-<dd>TypeScript, React, Next.js, React Native, JavaScript, Redux</dd>
+<dd>TypeScript, React, Next.js, React Native, Redux</dd>
 <dt>Server-side</dt>
 <dd>Node.js, Express, Python, Ruby, Shell scripting</dd>
 <dt>Web3 & Crypto</dt>


### PR DESCRIPTION
PR #63 was merged at the point where only the first commit (`8eccf04`) had landed on the branch. Four follow-up commits I pushed afterwards never made it into `main`. This PR brings them in.

## Commits (chronological order on the branch)

1. **`83541ee fix(cv): apply same formatting design to product variant`**
   Strip inline bold from product.md bullets; convert Kontainers + Fidelity to prose. Brings product into line with the formatting that landed for frontend / full-stack in #63.

2. **`9bb7c3c fix(cv): tighten frontend summary`**
   Replace "Specialises in React, TypeScript and Next.js, with deep React Native experience" with "Deep expertise in React, TypeScript, Next.js and React Native". Mirrored into LinkedIn template.

3. **`3f8ece3 chore(cv): refresh Kontainers and Fidelity copy across all variants`**
   Kontainers: drop "establishing the engineering culture at the seed stage" trailing clause.
   Fidelity: replace existing single-sentence summary with new copy opening "Responsible for building prototype fintech applications. Technical lead for an offshore development team…".
   Applied to all three CVs + LinkedIn template.

4. **`b940ce9 chore(cv): drop JavaScript from skills lists across all variants`**
   TypeScript alone covers the language signal. Removed from frontend / full-stack / product Front-End skill rows and both LinkedIn skill locations. "Lead JavaScript Developer" role title at Motocal and Kontainers stack reference left intact (historical role facts, not skills claims).

Build + 15 e2e CV tests pass on the tip.