### PR TITLE
Harden .gitignore to catch all .env variants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,10 +17,10 @@ dist/
 
 # misc
 .DS_Store
-.env.local
-.env.development.local
-.env.test.local
-.env.production.local
+.env
+.env.*
+!.env.example
+!.env.*.example
 
 npm-debug.log*
 yarn-debug.log*


### PR DESCRIPTION
## Summary
- Replace the four specific `.env.*.local` entries with `.env` + `.env.*` patterns so plain `.env`, `.env.production`, `.env.development`, and any future suffix are all gitignored by default
- Add `!.env.example` and `!.env.*.example` negations so committed template files still work
- Closes a gap surfaced during the audit: with the existing rules, a `.env` (no suffix) — the most common name in tutorials — was tracked by git