### PR TITLE
Homepage redesign: hero, logo strip, case studies, timeline

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,52 +1,683 @@
 ---
-import type { CollectionEntry } from 'astro:content';
 import BaseLayout from '../layouts/BaseLayout.astro';
-import OssContributions from '../components/OssContributions.astro';
-import BlogPostCard from '../components/BlogPostCard.astro';
-import { getCollection } from 'astro:content';
-
-const featuredPosts = (await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft && data.featured))
-  .sort((a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) => b.data.pubDate.valueOf() - a.data.pubDate.valueOf());
 ---
 
 <BaseLayout>
   <article class="homepage">
-    <section class="intro">
-      <p class="tagline">Senior Frontend Engineer — Bitcoin, Web3 and high-stakes fintech.</p>
-      <p>
-        Senior Frontend Engineer with over 15 years of experience leading frontend development
-        for high-traffic fintech, crypto and Web3 applications. Clean code practitioner, specialised
-        in React, TypeScript and React Native, with expertise in building scalable, user-focused
-        solutions. Demonstrated success in major product launches, optimising engineering workflows
-        and promoting cross-team collaboration.
+
+    <section class="hero">
+      <span class="availability-badge" data-reveal>
+        <span class="badge-dot" aria-hidden="true"></span>
+        Available September 2026
+      </span>
+      <h2 class="hero-name" data-reveal>Pete Watters</h2>
+      <p class="hero-words" aria-label="Builder, Engineer, Shipper">
+        <span class="hero-word hero-word--accent">Builder</span>
+        <span class="hero-word-sep" aria-hidden="true">·</span>
+        <span class="hero-word">Engineer</span>
+        <span class="hero-word-sep" aria-hidden="true">·</span>
+        <span class="hero-word hero-word--accent">Shipper</span>
       </p>
-      <p>
-        At <a href="https://trustmachines.co" target="_blank" rel="noopener noreferrer">Trust Machines</a>,
-        I am building <a href="https://leather.io" target="_blank" rel="noopener noreferrer">Leather Wallet</a> —
-        the most popular Bitcoin and Stacks wallet for DeFi, NFTs and BRC-20 tokens. I work on the
-        browser extension and React Native mobile app, which serves hundreds of thousands of users
-        across multiple Bitcoin layers.
+      <p class="hero-subtagline" data-reveal>PLAN IT · BUILD IT · SHIP IT</p>
+      <p class="hero-bio" data-reveal>
+        Ten years shipping crypto products people actually use — wallets, trading terminals,
+        institutional interfaces — across Bitcoin, Stacks, Solana and EVM chains. I take a brief
+        and turn it into production code, on web and mobile, faster than most teams.
       </p>
     </section>
 
-    <OssContributions />
+    <section class="logo-strip">
+      <p class="section-label">Shipped at</p>
+      <ul class="logo-strip-list">
+        <li data-reveal>Kraken</li>
+        <li data-reveal>Fidelity</li>
+        <li data-reveal>Bank of America</li>
+        <li data-reveal>Xapo</li>
+        <li data-reveal>Leather</li>
+        <li data-reveal>Qredo</li>
+      </ul>
+    </section>
 
-    {featuredPosts.length > 0 && (
-      <section class="recent-posts">
-        <h3>Writing</h3>
-        <ul class="blog-list">
-          {featuredPosts.map((post: CollectionEntry<'blog'>) => (
-            <BlogPostCard
-              title={post.data.title}
-              description={post.data.description}
-              pubDate={post.data.pubDate}
-              slug={post.id.replace(/\.md$/, '')}
-              tags={post.data.tags}
-            />
-          ))}
-        </ul>
-        <p class="view-all"><a href="/blog">View all posts &rarr;</a></p>
-      </section>
-    )}
+    <section class="case-studies">
+      <p class="section-label">Selected work</p>
+
+      <article class="case-card" data-reveal>
+        <div class="case-card-visual case-card-visual--leather" aria-hidden="true">
+          <div class="visual-placeholder">
+            <span class="placeholder-label">Leather Mobile</span>
+          </div>
+        </div>
+        <div class="case-card-content">
+          <p class="case-card-meta">
+            <span class="case-card-client">Trust Machines · Leather</span>
+            <span class="case-card-period">Jul 2023 — Present</span>
+          </p>
+          <h3 class="case-card-headline">
+            Worked on a Bitcoin wallet rebrand and shipped the first mobile app in three months.
+          </h3>
+          <p class="case-card-body">
+            Worked on the Hiro → Leather rebrand as a core team member — monorepo, Panda UI
+            component library, and BIP39 mnemonic validation. Managed the end-to-end launch
+            of the Leather mobile app from scratch in React Native. Hit 1,850+ MAU in three
+            months; extension serves 8,400+ MAU.
+          </p>
+          <ul class="tags case-card-tags">
+            <li>Bitcoin</li>
+            <li>Stacks</li>
+            <li>React Native</li>
+            <li>Design System</li>
+            <li>AI Tooling</li>
+          </ul>
+          <a class="case-card-link" href="/work/leather/">
+            View case study <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </div>
+      </article>
+
+      <article class="case-card" data-reveal>
+        <div class="case-card-visual case-card-visual--cryptowatch" aria-hidden="true">
+          <div class="terminal-mock">
+            <div class="terminal-bar">
+              <span class="terminal-dot terminal-dot--red"></span>
+              <span class="terminal-dot terminal-dot--amber"></span>
+              <span class="terminal-dot terminal-dot--green"></span>
+              <span class="terminal-title">Cryptowatch — BTC/USD</span>
+            </div>
+            <div class="terminal-body">
+              <div><span class="t-dim">exchange</span><span class="t-blue">kraken</span></div>
+              <div><span class="t-dim">pair    </span><span class="t-white">BTC / USD</span></div>
+              <div><span class="t-dim">price   </span><span class="t-green">$42,150.00</span></div>
+              <div><span class="t-dim">side    </span><span class="t-orange">buy</span></div>
+              <div><span class="t-dim">amount  </span><span class="t-white">0.1 BTC</span></div>
+              <div><span class="t-dim">leverage</span><span class="t-orange">——•—— 3×</span></div>
+              <div>&nbsp;</div>
+              <div><span class="t-green">› Order placed ✓</span></div>
+            </div>
+          </div>
+        </div>
+        <div class="case-card-content">
+          <p class="case-card-meta">
+            <span class="case-card-client">Kraken · Cryptowatch</span>
+            <span class="case-card-period">Aug 2020 — Nov 2022</span>
+          </p>
+          <h3 class="case-card-headline">
+            Built a greenfield trading automation tool solo — eight months, blank repo to MVP.
+          </h3>
+          <p class="case-card-body">
+            Cryptowatch served millions of traders across 25 exchanges and 4,000+ markets.
+            I was the sole frontend engineer on Coderunner — architecture, components, testing,
+            delivery. Also shipped the multi-exchange trading form, cockpit redesign, and
+            leverage slider for the wider platform.
+          </p>
+          <ul class="tags case-card-tags">
+            <li>Kraken</li>
+            <li>TypeScript</li>
+            <li>Trading</li>
+            <li>Security</li>
+          </ul>
+          <a class="case-card-link" href="/work/cryptowatch/">
+            View case study <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </div>
+      </article>
+
+      <article class="case-card" data-reveal>
+        <div class="case-card-visual case-card-visual--xapo" aria-hidden="true">
+          <div class="visual-placeholder">
+            <span class="placeholder-label">Xapo · 2017–2020</span>
+          </div>
+        </div>
+        <div class="case-card-content">
+          <p class="case-card-meta">
+            <span class="case-card-client">Xapo</span>
+            <span class="case-card-period">Nov 2017 — Apr 2020</span>
+          </p>
+          <h3 class="case-card-headline">
+            Designed the React + Next.js + Express blueprint adopted across every product team.
+          </h3>
+          <p class="case-card-body">
+            Full-stack application blueprint adopted as Xapo's company-wide engineering
+            standard. Built CI/CD and E2E testing standards from the ground up; led the core
+            product redesign squad. Completed private blockchain training with Andreas
+            Antonopoulos and Jimmy Song.
+          </p>
+          <ul class="tags case-card-tags">
+            <li>Bitcoin</li>
+            <li>Architecture</li>
+            <li>Next.js</li>
+            <li>CI/CD</li>
+          </ul>
+          <a class="case-card-link" href="/work/xapo/">
+            View case study <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </div>
+      </article>
+
+      <article class="case-card" data-reveal>
+        <div class="case-card-visual case-card-visual--qredo" aria-hidden="true">
+          <div class="visual-placeholder visual-placeholder--quiet">
+            <span class="placeholder-label">Qredo · 2023</span>
+          </div>
+        </div>
+        <div class="case-card-content">
+          <p class="case-card-meta">
+            <span class="case-card-client">Qredo</span>
+            <span class="case-card-period">Jan — Jun 2023</span>
+          </p>
+          <h3 class="case-card-headline">
+            Greenfield institutional DeFi trading interface — blank repo to shipped in six months.
+          </h3>
+          <p class="case-card-body">
+            Layer 2 institutional custodian protocol. Built the trading interface from
+            scratch — React, Redux Toolkit, MetaMask and WalletConnect integration — and
+            a Node.js ETH transaction parser for compliance teams.
+          </p>
+          <ul class="tags case-card-tags">
+            <li>Ethereum</li>
+            <li>DeFi</li>
+            <li>Institutional</li>
+            <li>MetaMask</li>
+            <li>Node.js</li>
+          </ul>
+          <a class="case-card-link" href="/work/qredo/">
+            View case study <span class="arrow" aria-hidden="true">→</span>
+          </a>
+        </div>
+      </article>
+    </section>
+
+    <section class="timeline">
+      <p class="section-label">Resume 2014 → 2026</p>
+      <ol class="timeline-rows">
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Trust Machines</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Senior Frontend Engineer</span>
+            <span class="timeline-role-blurb">Leather wallet · rebrand · mobile · AI workflow</span>
+          </div>
+          <div class="timeline-period">Jul 2023 — Present</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Qredo</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Senior Frontend Engineer</span>
+            <span class="timeline-role-blurb">Institutional DeFi · MetaMask · WalletConnect</span>
+          </div>
+          <div class="timeline-period">Jan — Jun 2023</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Kraken</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Senior Frontend Engineer</span>
+            <span class="timeline-role-blurb">Trading terminal · Coderunner · Codebashing champion</span>
+          </div>
+          <div class="timeline-period">Aug 2020 — Nov 2022</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Xapo</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Senior Frontend Engineer</span>
+            <span class="timeline-role-blurb">Architecture standard · CI/CD · 1.5M customers</span>
+          </div>
+          <div class="timeline-period">Nov 2017 — Apr 2020</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Bank of America</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Senior Frontend Engineer</span>
+            <span class="timeline-role-blurb">Investment tracking · TDD/BDD · Python/Django</span>
+          </div>
+          <div class="timeline-period">May — Oct 2017</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Rocksteady</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Lead JavaScript Developer</span>
+            <span class="timeline-role-blurb">Rescued failing app · first stable release in 7 months</span>
+          </div>
+          <div class="timeline-period">Apr 2016 — Mar 2017</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Kontainers</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Full-Stack Developer</span>
+            <span class="timeline-role-blurb">Seed-stage · inception to production · acquired by Descartes</span>
+          </div>
+          <div class="timeline-period">Jun 2015 — Apr 2016</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Fidelity</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">UX Developer</span>
+            <span class="timeline-role-blurb">Offshore team lead · R&amp;D accreditation</span>
+          </div>
+          <div class="timeline-period">Jun 2014 — Jun 2015</div>
+        </li>
+        <li class="timeline-row" data-reveal>
+          <div class="timeline-company">Earlier</div>
+          <div class="timeline-role">
+            <span class="timeline-role-name">Yahoo! · eSpatial · The Now Factory · IBM · HP</span>
+            <span class="timeline-role-blurb">From graduate to senior, building front-ends for enterprise</span>
+          </div>
+          <div class="timeline-period">2006 — 2014</div>
+        </li>
+      </ol>
+    </section>
+
   </article>
 </BaseLayout>
+
+<script>
+  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+
+  if (!reduceMotion && 'IntersectionObserver' in window) {
+    const observer = new IntersectionObserver((entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          const delay = Number(entry.target.getAttribute('data-stagger') || 0);
+          setTimeout(() => entry.target.classList.add('is-visible'), delay);
+          observer.unobserve(entry.target);
+        }
+      });
+    }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+    const groups = [
+      { selector: '.logo-strip-list [data-reveal]', step: 80 },
+      { selector: '.case-card[data-reveal]',        step: 120 },
+      { selector: '.timeline-row[data-reveal]',     step: 60 },
+    ];
+
+    groups.forEach(({ selector, step }) => {
+      document.querySelectorAll(selector).forEach((el, i) => {
+        el.setAttribute('data-stagger', String(i * step));
+      });
+    });
+
+    document.querySelectorAll('[data-reveal]').forEach((el) => observer.observe(el));
+  } else {
+    document.querySelectorAll('[data-reveal]').forEach((el) => el.classList.add('is-visible'));
+  }
+</script>
+
+<style>
+  main:has(> .homepage) {
+    max-width: none;
+    padding-left: 0;
+    padding-right: 0;
+    text-align: left;
+  }
+
+  .homepage {
+    --color-accent: #F7931A;
+    --homepage-max: 1080px;
+    --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+    max-width: var(--homepage-max);
+    margin: 0 auto;
+    padding: 1.5rem 1.5rem 4rem;
+    text-align: left;
+  }
+
+  .homepage section { margin-bottom: 5rem; }
+
+  [data-reveal] {
+    opacity: 0;
+    transform: translateY(12px);
+    transition:
+      opacity 0.6s var(--ease-out-soft),
+      transform 0.6s var(--ease-out-soft);
+    will-change: opacity, transform;
+  }
+  [data-reveal].is-visible {
+    opacity: 1;
+    transform: translateY(0);
+  }
+
+  /* HERO */
+  .hero { padding: 3rem 0 2rem; }
+
+  .availability-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+    background: rgba(247, 147, 26, 0.06);
+    border: 1px solid rgba(247, 147, 26, 0.25);
+    padding: 0.35rem 0.75rem;
+    border-radius: 999px;
+    margin-bottom: 2rem;
+  }
+
+  .badge-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: var(--color-accent);
+    animation: badge-pulse 2.5s ease-in-out infinite;
+  }
+  @keyframes badge-pulse {
+    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(247, 147, 26, 0.4); }
+    50%      { opacity: 0.6; box-shadow: 0 0 0 6px rgba(247, 147, 26, 0); }
+  }
+
+  .hero-name {
+    font-family: 'Monoton', cursive;
+    font-weight: 400;
+    font-size: clamp(2.2rem, 7vw, 4.5rem);
+    line-height: 1.05;
+    margin: 0 0 1.5rem;
+    color: var(--color-text);
+  }
+
+  .hero-words {
+    font-family: var(--font-mono);
+    font-size: clamp(1.4rem, 3.5vw, 2.2rem);
+    font-weight: 500;
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem;
+    align-items: baseline;
+  }
+
+  .hero-word,
+  .hero-word-sep {
+    opacity: 0;
+    transform: translateY(10px);
+    animation: hero-word-up 0.6s var(--ease-out-soft) forwards;
+    display: inline-block;
+    color: var(--color-text);
+  }
+  .hero-word--accent { color: var(--color-accent); }
+  .hero-word-sep    { color: var(--color-faint); }
+
+  .hero-words > *:nth-child(1) { animation-delay: 0.35s; }
+  .hero-words > *:nth-child(2) { animation-delay: 0.45s; }
+  .hero-words > *:nth-child(3) { animation-delay: 0.55s; }
+  .hero-words > *:nth-child(4) { animation-delay: 0.65s; }
+  .hero-words > *:nth-child(5) { animation-delay: 0.75s; }
+
+  @keyframes hero-word-up {
+    to { opacity: 1; transform: translateY(0); }
+  }
+
+  .hero-subtagline {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    letter-spacing: 0.3em;
+    color: var(--color-faint);
+    text-transform: uppercase;
+    margin: 0 0 2.5rem;
+  }
+
+  .hero-bio {
+    font-size: clamp(1.05rem, 1.6vw, 1.2rem);
+    line-height: 1.65;
+    color: var(--color-text);
+    max-width: 38em;
+    margin: 0;
+  }
+
+  /* LOGO STRIP */
+  .logo-strip { padding-top: 1rem; }
+
+  .logo-strip-list {
+    list-style: none;
+    padding: 0;
+    margin: 1rem 0 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.25rem 2.5rem;
+    align-items: center;
+  }
+
+  .logo-strip-list li {
+    font-family: var(--font-mono);
+    font-size: 15px;
+    font-weight: 500;
+    color: var(--color-faint);
+    transition:
+      color 0.3s var(--ease-out-soft),
+      transform 0.3s var(--ease-out-soft);
+    cursor: default;
+  }
+
+  .logo-strip-list li:hover {
+    color: var(--color-text);
+    transform: translateY(-1px);
+  }
+
+  /* CASE STUDY CARDS */
+  .case-studies .section-label { margin-bottom: 2rem; }
+
+  .case-card {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 3rem;
+    align-items: center;
+    margin: 4rem 0;
+  }
+
+  /* alternating layout — odd-indexed cards (1, 3) place visual on the right (text-left),
+     even-indexed cards (2, 4) keep visual on the left (text-right) */
+  .case-card:nth-of-type(odd) .case-card-visual { order: 2; }
+
+  .case-card-visual {
+    aspect-ratio: 4 / 3;
+    border: 1px solid var(--color-border);
+    border-radius: 0.75rem;
+    overflow: hidden;
+    background: #fafafa;
+    transition: transform 0.4s var(--ease-out-soft), border-color 0.3s var(--ease-out-soft);
+  }
+
+  .case-card:hover .case-card-visual {
+    transform: translateY(-3px);
+    border-color: var(--color-faint);
+  }
+
+  .visual-placeholder {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #f5f5f5 0%, #eaeaea 100%);
+  }
+
+  .visual-placeholder--quiet {
+    background: linear-gradient(135deg, #fafafa 0%, #f0f0f0 100%);
+  }
+
+  .placeholder-label {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-faint);
+    letter-spacing: 0.05em;
+  }
+
+  /* terminal mock — Cryptowatch */
+  .terminal-mock {
+    width: 100%;
+    height: 100%;
+    background: #0D1117;
+    display: flex;
+    flex-direction: column;
+    font-family: var(--font-mono);
+    font-size: 12px;
+  }
+
+  .terminal-bar {
+    display: flex;
+    align-items: center;
+    gap: 0.4rem;
+    padding: 0.55rem 0.8rem;
+    background: #161B22;
+    border-bottom: 1px solid #21262D;
+  }
+
+  .terminal-dot {
+    width: 10px;
+    height: 10px;
+    border-radius: 50%;
+  }
+  .terminal-dot--red   { background: #FF5F56; }
+  .terminal-dot--amber { background: #FFBD2E; }
+  .terminal-dot--green { background: #27C93F; }
+
+  .terminal-title {
+    margin-left: 0.5rem;
+    font-size: 11px;
+    color: #8B949E;
+  }
+
+  .terminal-body {
+    padding: 0.85rem 1rem;
+    color: #C9D1D9;
+    flex: 1;
+  }
+  .terminal-body > div { display: flex; gap: 1.25rem; line-height: 1.55; }
+  .t-dim    { color: #6E7681; min-width: 5rem; display: inline-block; }
+  .t-white  { color: #F0F6FC; }
+  .t-blue   { color: #79C0FF; }
+  .t-green  { color: #56D364; }
+  .t-orange { color: #F7931A; }
+
+  .case-card-meta {
+    margin: 0 0 1rem;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 1rem;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+  }
+
+  .case-card-client { color: var(--color-accent); font-weight: 600; }
+  .case-card-period { color: var(--color-faint); }
+
+  .case-card-headline {
+    margin: 0 0 1rem;
+    font-size: clamp(1.25rem, 2.2vw, 1.6rem);
+    font-weight: 600;
+    line-height: 1.3;
+    color: var(--color-text);
+  }
+
+  .case-card-body {
+    margin: 0 0 1.25rem;
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--color-muted);
+  }
+
+  .case-card-tags { margin-bottom: 1.25rem; }
+
+  .case-card-link {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-text);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    padding-bottom: 1px;
+    transition: border-color 0.25s var(--ease-out-soft);
+  }
+  .case-card-link:hover { border-bottom-color: var(--color-text); }
+  .case-card-link .arrow {
+    display: inline-block;
+    transition: transform 0.3s var(--ease-out-soft);
+  }
+  .case-card-link:hover .arrow { transform: translateX(4px); }
+
+  /* TIMELINE */
+  .timeline .section-label { margin-bottom: 1.5rem; }
+
+  .timeline-rows {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    border-top: 1px solid var(--color-border);
+  }
+
+  .timeline-row {
+    display: grid;
+    grid-template-columns: 1.4fr 2.6fr 1.2fr;
+    gap: 1.5rem;
+    padding: 1.1rem 0;
+    border-bottom: 1px solid var(--color-border);
+    align-items: baseline;
+  }
+
+  .timeline-company {
+    font-weight: 600;
+    color: var(--color-text);
+  }
+
+  .timeline-role {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+  }
+
+  .timeline-role-name {
+    color: var(--color-text);
+    font-size: 0.95rem;
+  }
+
+  .timeline-role-blurb {
+    color: var(--color-muted);
+    font-size: 0.9rem;
+    line-height: 1.5;
+  }
+
+  .timeline-period {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-faint);
+    text-align: right;
+    white-space: nowrap;
+  }
+
+  /* RESPONSIVE */
+  @media (max-width: 900px) {
+    .case-card {
+      grid-template-columns: 1fr;
+      gap: 1.5rem;
+      margin: 3rem 0;
+    }
+    .case-card:nth-of-type(odd) .case-card-visual { order: 0; }
+    .case-card-visual { aspect-ratio: 16 / 10; }
+
+    .timeline-row {
+      grid-template-columns: 1fr;
+      gap: 0.25rem;
+      padding: 1rem 0;
+    }
+    .timeline-period { text-align: left; }
+  }
+
+  @media (max-width: 540px) {
+    .homepage { padding: 1rem 1.25rem 3rem; }
+    .homepage section { margin-bottom: 3.5rem; }
+    .hero { padding: 1.5rem 0 1rem; }
+    .hero-words { gap: 0.4rem; }
+    .logo-strip-list { gap: 0.9rem 1.5rem; }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    [data-reveal],
+    .hero-word,
+    .hero-word-sep,
+    .badge-dot {
+      animation: none !important;
+      transition: none !important;
+      opacity: 1;
+      transform: none;
+    }
+  }
+</style>

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -1,67 +1,60 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Home page', () => {
-  test('loads and shows intro', async ({ page }) => {
-    await page.goto('/');
-    await expect(page.locator('.intro').first()).toContainText('Senior Frontend Engineer');
-  });
-
   test('has correct title', async ({ page }) => {
     await page.goto('/');
     await expect(page).toHaveTitle('Pete Watters');
   });
 
-  test('shows OSS contributions section', async ({ page }) => {
+  test('hero shows availability badge', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.oss-section h3')).toHaveText('Open Source');
-    const cards = page.locator('.oss-card');
-    await expect(cards).toHaveCount(2);
+    await expect(page.locator('.availability-badge')).toContainText('Available September 2026');
   });
 
-  test('displays repo links with full org/repo names', async ({ page }) => {
+  test('hero shows name and the three words', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('a.oss-repo-name[href*="leather-io/extension"]')).toHaveText('leather-io/extension');
-    await expect(page.locator('a.oss-repo-name[href*="leather-io/mono"]')).toHaveText('leather-io/mono');
+    await expect(page.locator('.hero-name')).toHaveText('Pete Watters');
+    const words = page.locator('.hero-word');
+    await expect(words).toHaveCount(3);
+    await expect(words.nth(0)).toHaveText('Builder');
+    await expect(words.nth(1)).toHaveText('Engineer');
+    await expect(words.nth(2)).toHaveText('Shipper');
   });
 
-  test('OSS PR counts link to filtered GitHub pulls page', async ({ page }) => {
+  test('hero shows sub-tagline and bio', async ({ page }) => {
     await page.goto('/');
-    const prLink = page.locator('.oss-stat a[href*="/pulls?q="]').first();
-    await expect(prLink).toBeVisible();
-    await expect(prLink).toHaveAttribute('href', /\/pulls\?q=is:pr\+is:merged\+author:pete-watters/);
+    await expect(page.locator('.hero-subtagline')).toContainText('PLAN IT');
+    await expect(page.locator('.hero-bio')).toContainText('crypto products');
   });
 
-  test('OSS commit counts link to filtered GitHub commits page', async ({ page }) => {
+  test('logo strip lists all six companies', async ({ page }) => {
     await page.goto('/');
-    const commitLink = page.locator('.oss-stat a[href*="/commits?author="]').first();
-    await expect(commitLink).toBeVisible();
-    await expect(commitLink).toHaveAttribute('href', /\/commits\?author=pete-watters/);
+    const items = page.locator('.logo-strip-list li');
+    await expect(items).toHaveCount(6);
+    await expect(items.nth(0)).toHaveText('Kraken');
+    await expect(items.nth(5)).toHaveText('Qredo');
   });
 
-  test('shows fallback PR and commit numbers', async ({ page }) => {
+  test('shows four case study cards', async ({ page }) => {
     await page.goto('/');
-    const numbers = page.locator('.oss-number');
-    await expect(numbers).toHaveCount(4);
-    for (const el of await numbers.all()) {
-      const text = await el.textContent();
-      expect(Number(text)).toBeGreaterThan(0);
-    }
+    await expect(page.locator('.case-card')).toHaveCount(4);
   });
 
-  test('shows recent blog posts', async ({ page }) => {
+  test('case study cards link to /work/<slug>/', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.recent-posts > h3')).toHaveText('Writing');
-    await expect(page.locator('.recent-posts .blog-card').first()).toBeVisible();
+    const links = page.locator('.case-card-link');
+    await expect(links).toHaveCount(4);
+    await expect(links.nth(0)).toHaveAttribute('href', '/work/leather/');
+    await expect(links.nth(1)).toHaveAttribute('href', '/work/cryptowatch/');
+    await expect(links.nth(2)).toHaveAttribute('href', '/work/xapo/');
+    await expect(links.nth(3)).toHaveAttribute('href', '/work/qredo/');
   });
 
-  test('has view all posts link', async ({ page }) => {
+  test('timeline lists every role from Trust Machines back to Earlier', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.view-all a[href="/blog"]')).toBeVisible();
-  });
-
-  test('view all posts link navigates to blog', async ({ page }) => {
-    await page.goto('/');
-    await page.click('.view-all a[href="/blog"]');
-    await expect(page).toHaveURL('/blog');
+    const rows = page.locator('.timeline-row');
+    await expect(rows).toHaveCount(9);
+    await expect(rows.first().locator('.timeline-company')).toHaveText('Trust Machines');
+    await expect(rows.last().locator('.timeline-company')).toHaveText('Earlier');
   });
 });


### PR DESCRIPTION
## Summary
- New hero: pulsing availability badge, Monoton-styled name (matches existing nav wordmark), three-word callout (Builder · Engineer · Shipper) with staggered fade-up, mono sub-tagline, bio block
- Logo strip "Shipped at" — six companies, staggered fade-in on scroll via IntersectionObserver, hover brightens
- Four case study cards alternating text-left/image-right ↔ image-left/text-right at desktop, single-column on mobile. Card 1 = Leather (placeholder visual), Card 2 = Cryptowatch (terminal mockup baked in), Card 3 = Xapo (placeholder), Card 4 = Qredo (quiet placeholder). Each links to /work/<slug>/ — those pages land in PR 2 of 4
- Timeline section: nine roles from Trust Machines back to "Earlier", three-column grid (company / role + blurb / period) on desktop, stacked on mobile
- Bitcoin orange (#F7931A) introduced as `--color-accent` scoped to the homepage only — used on availability dot, accent words, client names
- Homepage widens to 1080px via `main:has(> .homepage)`; all other pages stay at 680px
- All animations CSS + vanilla JS only — no libraries. Respects `prefers-reduced-motion`
- Replaces OssContributions and Writing/featured-posts sections on the homepage (per your call) — components remain available for use elsewhere
- e2e tests updated to match new structure (badge, hero, logo strip, case cards, timeline rows)

## Notes for review
- Header (nav, Monoton wordmark, avatar) untouched — preserved exactly per brief's brand constraints
- Case study links 404 until PR 2 lands the /work/<slug>/ pages — sequence merges accordingly
- Trust Machines verbs use "Worked on / contributed" framing per your memory rule
- Stats canonical: 8,400 extension MAU + 1,850 mobile MAU (matches existing CV phrasing)
- "Konteveloper" gap from the brief filled in silently as Kontainers · Full-Stack Developer (pulled from your CV)