### PR TITLE
Case study pages: /work/{leather,cryptowatch,xapo,qredo}/

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -20,4 +20,27 @@ const cv = defineCollection({
   }),
 });
 
-export const collections = { blog, cv };
+const work = defineCollection({
+  type: 'content',
+  schema: z.object({
+    title: z.string(),
+    company: z.string(),
+    project: z.string().optional(),
+    role: z.string(),
+    period: z.string(),
+    stat: z.string().optional(),
+    headline: z.string(),
+    subtitle: z.string().optional(),
+    confidentiality: z.string(),
+    tech: z.array(z.string()),
+    order: z.number(),
+    outcomeText: z.string().optional(),
+    outcomeStats: z.array(z.object({
+      number: z.string(),
+      label: z.string(),
+    })).optional(),
+    draft: z.boolean().default(false),
+  }),
+});
+
+export const collections = { blog, cv, work };

--- a/src/content/work/cryptowatch.md
+++ b/src/content/work/cryptowatch.md
@@ -1,0 +1,54 @@
+---
+title: "Cryptowatch"
+company: "Kraken"
+project: "Cryptowatch"
+role: "Senior Frontend Engineer"
+period: "August 2020 — November 2022"
+stat: "Millions of traders · 25 exchanges · 4,000+ markets"
+headline: "Sole frontend engineer on a greenfield trading automation tool — eight months from blank repo to MVP."
+subtitle: "Cryptowatch was a real-time charting and trading terminal acquired by Kraken and later integrated into Kraken Pro."
+confidentiality: "This case study describes my personal contributions. Cryptowatch has since been integrated into Kraken Pro. Details reflect my own experience and do not represent official Kraken communications."
+tech:
+  - React
+  - TypeScript
+  - PostCSS
+  - Redux
+  - Cypress
+  - WebSocket APIs
+  - Trading
+  - Security
+order: 2
+outcomeText: "Eight months blank-repo to MVP · Sole frontend on Coderunner · Shipped trading form, cockpit redesign and leverage slider for the wider platform · Codebashing security champion 2020."
+---
+
+## Overview
+
+Cryptowatch served millions of active traders across 25 exchanges and over 4,000 markets. I joined in August 2020 and shipped components, features, and a full greenfield product over two years.
+
+## The problem
+
+Two things ran in parallel.
+
+The wider Cryptowatch platform needed senior frontend work — a redesigned cockpit, a multi-exchange trading form, and a leverage slider for the trade-execution flow. These were high-traffic, mission-critical surfaces.
+
+Separately, the team wanted to build a new product called Coderunner — a greenfield trading automation tool. It needed an engineer who could take a brief and turn it into a shipped MVP. There was no existing codebase to lean on.
+
+## What I built
+
+### Chapter 1 — Coderunner, the greenfield product
+
+I was the sole frontend engineer on Coderunner. Architecture, component implementation, testing, delivery — all mine. Eight months from blank repo to MVP.
+
+The dynamic form-generation system was the hardest part. Strategy configurations had to support consistent field types — market picker, asset-aware amount input, precision-aware currency handling — without one-off form code per strategy. Built in React and TypeScript on top of PostCSS, with a custom field-type system that kept the strategy authors fast and the UI consistent.
+
+### Chapter 2 — The trading form and leverage slider
+
+On the wider Cryptowatch platform, I shipped the multi-exchange trading form, the cockpit redesign, and the leverage slider that fronted real money on real positions.
+
+Trading UI is one of the unforgiving surfaces in frontend. A leverage slider that snaps wrong, or a price field that rounds the wrong way, costs users actual money. Every component went through Cypress E2E coverage I built up over the project's lifetime.
+
+### Chapter 3 — Security — Codebashing champion 2020
+
+I won Kraken's company-wide Codebashing security challenge in 2020, placing first across the engineering organisation for expertise in client-side vulnerabilities and OWASP mitigations. On a real-money trading platform, that mattered.
+
+I also initiated a Cypress E2E testing framework for Cryptowatch as a side project. It became part of the team's regression baseline.

--- a/src/content/work/leather.md
+++ b/src/content/work/leather.md
@@ -1,0 +1,93 @@
+---
+title: "Leather Bitcoin Wallet"
+company: "Trust Machines"
+project: "Leather Bitcoin Wallet"
+role: "Senior Frontend Engineer"
+period: "July 2023 — Present"
+stat: "62,000+ users in six months · 1,850+ mobile MAU"
+headline: "A Bitcoin wallet rebrand, a shared design system, and the first mobile app — across web and mobile."
+subtitle: "Leather is an open-source, self-custodial Bitcoin and Stacks wallet. I joined Trust Machines as a core engineer to help ship it."
+confidentiality: "This case study describes my personal contributions as a contractor at Trust Machines. The Leather wallet is open source — my work is publicly visible at github.com/leather-io. Technical details reflect my own experience and do not represent official Trust Machines communications."
+tech:
+  - React Native
+  - Expo
+  - TypeScript
+  - Panda CSS
+  - Radix UI
+  - Redux
+  - Maestro
+  - Vitest
+  - Cypress
+  - Bitcoin
+  - Stacks
+  - sBTC
+  - Bitcoin Ordinals
+  - Claude Code
+  - Mono-repo architecture
+order: 1
+outcomeStats:
+  - number: "8,400+"
+    label: "Monthly active extension users"
+  - number: "62,000+"
+    label: "Extension users over six months"
+  - number: "1,850+"
+    label: "Mobile MAU within three months of launch"
+  - number: "2"
+    label: "Platforms sharing one design system"
+  - number: "1"
+    label: "Mobile app shipped to App Store and Play Store"
+---
+
+## Overview
+
+Leather (formerly Hiro Wallet) is a self-custodial Bitcoin wallet serving tens of thousands of users across a browser extension and mobile app. It supports Bitcoin, Stacks, sBTC, and Bitcoin Ordinals.
+
+I joined as a senior frontend engineer in July 2023 as a core team member, working on the Hiro → Leather rebrand, the mono-repo architecture, the shared design system, and the launch of the first Leather mobile app.
+
+## The problem
+
+When I joined, the product faced three simultaneous challenges.
+
+The rebrand from Hiro Wallet to Leather needed to ship — new name, new visual identity, new domain — without breaking the experience for existing users managing real Bitcoin.
+
+The codebase had no shared component system. The extension and any future mobile product would duplicate work indefinitely without one.
+
+And there was no mobile app. Leather existed only as a browser extension. A significant portion of the Bitcoin user base — especially in emerging markets — needed a native mobile experience.
+
+All three needed to move at once.
+
+## What I built
+
+### Chapter 1 — The rebrand
+
+The Hiro → Leather rebrand wasn't cosmetic. Every surface of the extension needed updating: icons, copy, domain references, app store metadata, and the security-critical mnemonic login flow.
+
+On the login form, I implemented BIP39 word-level validation using `@scure/bip39` — the first time Leather had per-word feedback instead of a single failure at submission. Get one word wrong restoring a Bitcoin wallet and you derive a completely different set of keys. The user won't know until they see an empty wallet and wonder where their Bitcoin went.
+
+The rebrand shipped to 8,400+ monthly active extension users. Over six months, 62,000+ users moved through the updated experience.
+
+*(See the related blog post: [Mnemonic Validation with @scure/bip39](/blog/mnemonic-validation/).)*
+
+### Chapter 2 — The mono-repo and design system
+
+Before a mobile app could ship, there needed to be shared infrastructure. As a core team member, I worked on a mono-repo to house the extension, mobile app, and shared packages under one roof.
+
+The centrepiece was Panda UI — a shared component library built with Panda CSS and Radix UI primitives. Components defined once, consumed by both the extension and the React Native app without duplication.
+
+This wasn't just a technical decision. Every hour saved on component maintenance is an hour that goes into shipping product. For a small team building across multiple surfaces, that compounded quickly.
+
+### Chapter 3 — The mobile app
+
+The first Leather mobile app launched on iOS and Android. I managed the end-to-end launch: architecture, component implementation, navigation, wallet connection, testing with Maestro, and App Store submission.
+
+Built with React Native and Expo, it shares business logic and UI primitives with the extension through the mono-repo.
+
+1,850+ monthly active users in the first three months.
+
+I represented the team at the Bitcoin Conference 2025 in Las Vegas for the mobile launch.
+
+### Chapter 4 — The NFT gallery and AI workflow
+
+I shipped the multi-chain NFT gallery — supporting Stacks SIP-9 tokens and Bitcoin Ordinals, including video and audio playback. The technical challenge was normalising two very different on-chain data models into a single coherent UI.
+
+I was also an early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team. We shipped faster without cutting corners on the wallet's review and testing standards.

--- a/src/content/work/qredo.md
+++ b/src/content/work/qredo.md
@@ -1,0 +1,47 @@
+---
+title: "Qredo"
+company: "Qredo"
+role: "Senior Frontend Engineer"
+period: "January — June 2023"
+stat: "Greenfield to shipped in six months"
+headline: "A greenfield institutional DeFi trading interface, blank repo to shipped in six months."
+subtitle: "Qredo was a Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network."
+confidentiality: "This case study describes my personal contributions as a contractor at Qredo. Some details have been omitted to respect confidentiality obligations. Details reflect my own experience and do not represent official Qredo communications."
+tech:
+  - React
+  - Redux Toolkit
+  - Material UI
+  - styled-components
+  - Node.js
+  - MetaMask
+  - WalletConnect
+  - Ethereum
+order: 4
+outcomeText: "Full institutional trading interface built from zero · MetaMask and WalletConnect integration live · Node.js ETH transaction parser delivered for compliance."
+---
+
+## Overview
+
+Qredo was a Layer 2 institutional custodian protocol — the part of the stack that institutional asset managers use to hold and move on-chain assets without surrendering custody of their private keys. I joined as a senior frontend engineer in January 2023 for a six-month engagement.
+
+## The problem
+
+Two distinct pieces.
+
+The platform needed a new institutional trading interface — somewhere asset managers could place trades, view balances, and connect external wallets. None of that existed yet.
+
+Compliance teams also needed a way to audit on-chain Ethereum activity in human-readable form. The raw transaction format is unforgiving — addresses, nonces, hex data — and not something a compliance analyst can sign off on at speed.
+
+## What I built
+
+### Chapter 1 — The institutional trading interface
+
+Built the trading interface from scratch in React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and the Qredo WebAPI so institutional clients could sign transactions on the Qredo network without leaving the app.
+
+The institutional context shaped every decision — the interface had to be auditable, the wallet flows had to handle multi-sig approval explicitly, and the data flow had to make confusion impossible. There's a different bar for trading interfaces that move other people's money.
+
+### Chapter 2 — The ETH transaction parser
+
+Built a Node.js ETH transaction parser to present on-chain history in human-readable form. Raw transactions came in; structured, labelled, compliance-friendly output came out. The compliance team could read it without having to interpret hex.
+
+*(See the related blog post: [Human-readable Ethereum transactions](/blog/human-readable-ethereum-transactions/).)*

--- a/src/content/work/xapo.md
+++ b/src/content/work/xapo.md
@@ -1,0 +1,50 @@
+---
+title: "Xapo"
+company: "Xapo"
+role: "Senior Frontend Engineer"
+period: "November 2017 — April 2020"
+stat: "1.5M+ customers · Blueprint adopted company-wide"
+headline: "Designed the React + Next.js + Express blueprint adopted across every product team at a 1.5M-customer Bitcoin company."
+subtitle: "Xapo was a global Bitcoin custody and multi-currency wallet platform. The architecture and tooling I introduced became the company's frontend standard."
+confidentiality: "Xapo has since rebranded to Xapo Bank. This case study describes work on the original Xapo wallet product. Details reflect my personal contributions and do not represent official Xapo communications."
+tech:
+  - React
+  - Next.js
+  - Express
+  - Node.js
+  - Docker
+  - Cypress
+  - styled-components
+  - Architecture
+  - CI/CD
+order: 3
+outcomeText: "Blueprint adopted as company-wide engineering standard · CI/CD and E2E testing built from zero · Core product redesign squad led to delivery · Private blockchain training with Andreas Antonopoulos and Jimmy Song."
+---
+
+## Overview
+
+Xapo was a fully remote global fintech providing multi-currency digital wallets and Bitcoin custody to over 1.5 million customers worldwide. I joined as a senior frontend engineer in November 2017 and stayed through April 2020.
+
+## The problem
+
+The frontend teams were building product against different stacks, with no shared architecture, no shared CI, and no shared testing baseline. Every new product surface meant re-deciding the basics. That slowed delivery and made cross-team review difficult.
+
+## What I built
+
+### Chapter 1 — The architecture blueprint
+
+I designed a full-stack application blueprint — React, Next.js and Express — that became Xapo's company-wide engineering standard, adopted across multiple product teams. The blueprint included a server-rendering pattern, conventions for state management, an HTTPS-terminated Express layer, and consistent project layout.
+
+The pattern's first live use was a standalone web app for identity verification, account freezing, and password recovery — separate from the main mobile product but sharing the same architectural shape. I wrote about that work [in the Next.js verify flow post](/blog/xapo-nextjs-verify-flow/).
+
+### Chapter 2 — CI/CD and E2E testing from zero
+
+There was no shared CI/CD pipeline when I joined. I built one — Docker-based, environment-aware, with Cypress E2E coverage layered on top. Manual QA cycle time dropped; release confidence went up.
+
+### Chapter 3 — Core product redesign squad
+
+Led the core product squad responsible for a comprehensive web platform redesign. The redesign shipped to existing customers without breaking the trust relationships they had with the wallet — the standard requirement for anything touching real money.
+
+### Chapter 4 — Blockchain training
+
+Completed private blockchain engineering training, including live sessions with Andreas Antonopoulos and a multi-day Bitcoin programming course with Jimmy Song. Working on a Bitcoin custody platform without understanding the protocol underneath felt like cheating; the training closed that gap.

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -1,0 +1,310 @@
+---
+import type { CollectionEntry } from 'astro:content';
+import { getCollection, render } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export async function getStaticPaths() {
+  const entries = await getCollection('work', ({ data }: CollectionEntry<'work'>) => !data.draft);
+  return entries.map((entry: CollectionEntry<'work'>) => ({
+    params: { slug: entry.id.replace(/\.md$/, '') },
+    props: { entry },
+  }));
+}
+
+interface Props {
+  entry: CollectionEntry<'work'>;
+}
+
+const { entry } = Astro.props;
+const { Content } = await render(entry);
+const data = entry.data;
+---
+
+<BaseLayout
+  title={data.title}
+  description={data.subtitle ?? data.headline}
+>
+  <article class="case-study">
+    <a href="/" class="case-study-back" data-position="top">← All work</a>
+
+    <header class="case-study-hero">
+      <p class="case-study-meta">
+        <span class="meta-company">{data.company}</span>
+        {data.project && <span class="meta-sep" aria-hidden="true">·</span>}
+        {data.project && <span class="meta-project">{data.project}</span>}
+        <span class="meta-sep" aria-hidden="true">·</span>
+        <span class="meta-role">{data.role}</span>
+        <span class="meta-sep" aria-hidden="true">·</span>
+        <span class="meta-period">{data.period}</span>
+      </p>
+      {data.stat && <p class="case-study-stat">{data.stat}</p>}
+      <h1 class="case-study-headline">{data.headline}</h1>
+      {data.subtitle && <p class="case-study-subtitle">{data.subtitle}</p>}
+    </header>
+
+    <aside class="case-study-notice">
+      <span class="notice-icon" aria-hidden="true">⚠</span>
+      <span>{data.confidentiality}</span>
+    </aside>
+
+    <div class="case-study-body">
+      <Content />
+    </div>
+
+    <section class="case-study-outcome">
+      <h2 class="case-study-section-title">Outcome</h2>
+      {data.outcomeStats && data.outcomeStats.length > 0 && (
+        <dl class="outcome-grid">
+          {data.outcomeStats.map((stat) => (
+            <div class="outcome-stat">
+              <dt class="outcome-number">{stat.number}</dt>
+              <dd class="outcome-label">{stat.label}</dd>
+            </div>
+          ))}
+        </dl>
+      )}
+      {data.outcomeText && (
+        <p class="outcome-text">{data.outcomeText}</p>
+      )}
+    </section>
+
+    <section class="case-study-tech">
+      <h2 class="case-study-section-title">Tech</h2>
+      <ul class="tags case-study-tech-list">
+        {data.tech.map((t) => <li>{t}</li>)}
+      </ul>
+    </section>
+
+    <a href="/" class="case-study-back case-study-back--end">← All work</a>
+  </article>
+</BaseLayout>
+
+<style>
+  main:has(> .case-study) {
+    max-width: none;
+    padding-left: 0;
+    padding-right: 0;
+    text-align: left;
+  }
+
+  .case-study {
+    --color-accent: #F7931A;
+    --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+    max-width: 880px;
+    margin: 0 auto;
+    padding: 1.5rem 1.5rem 4rem;
+    text-align: left;
+  }
+
+  .case-study-back {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.35rem;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-muted);
+    text-decoration: none;
+    padding: 0.25rem 0;
+    margin-bottom: 2rem;
+    border-bottom: 1px solid transparent;
+    transition: color 0.25s var(--ease-out-soft), border-color 0.25s var(--ease-out-soft);
+  }
+  .case-study-back:hover {
+    color: var(--color-text);
+    border-bottom-color: var(--color-text);
+  }
+  .case-study-back--end { margin: 4rem 0 0; }
+
+  /* HERO */
+  .case-study-hero {
+    padding: 1rem 0 2.5rem;
+    border-bottom: 1px solid var(--color-border);
+    margin-bottom: 2.5rem;
+  }
+
+  .case-study-meta {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.4rem 0.6rem;
+    align-items: center;
+    margin: 0 0 1rem;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    letter-spacing: 0.05em;
+    color: var(--color-muted);
+  }
+  .meta-company { color: var(--color-accent); font-weight: 600; }
+  .meta-project { color: var(--color-text); }
+  .meta-role    { color: var(--color-muted); }
+  .meta-period  { color: var(--color-faint); }
+  .meta-sep     { color: var(--color-faint); }
+
+  .case-study-stat {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-accent);
+    margin: 0 0 1.5rem;
+    letter-spacing: 0.02em;
+  }
+
+  .case-study-headline {
+    font-family: var(--font-sans);
+    font-size: clamp(1.8rem, 4vw, 2.6rem);
+    font-weight: 600;
+    line-height: 1.25;
+    margin: 0 0 1rem;
+    color: var(--color-text);
+  }
+
+  .case-study-subtitle {
+    font-size: clamp(1.05rem, 1.5vw, 1.15rem);
+    line-height: 1.6;
+    color: var(--color-muted);
+    margin: 0;
+    max-width: 38em;
+  }
+
+  /* CONFIDENTIALITY NOTICE */
+  .case-study-notice {
+    display: flex;
+    gap: 0.75rem;
+    align-items: flex-start;
+    padding: 0.9rem 1.1rem;
+    margin: 0 0 3rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    background: rgba(247, 147, 26, 0.03);
+    font-family: var(--font-sans);
+    font-size: 13px;
+    line-height: 1.55;
+    color: var(--color-muted);
+  }
+  .notice-icon {
+    color: var(--color-accent);
+    font-size: 14px;
+    line-height: 1.6;
+    flex-shrink: 0;
+  }
+
+  /* BODY */
+  .case-study-body {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--color-text);
+  }
+
+  .case-study-body :global(h2) {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-faint);
+    margin: 3.5rem 0 0.75rem;
+  }
+
+  .case-study-body :global(h3) {
+    font-family: var(--font-sans);
+    font-size: clamp(1.2rem, 2vw, 1.4rem);
+    font-weight: 600;
+    margin: 2.5rem 0 0.75rem;
+    color: var(--color-text);
+  }
+
+  .case-study-body :global(p) {
+    margin: 0 0 1.1rem;
+    max-width: 38em;
+  }
+
+  .case-study-body :global(p em) {
+    color: var(--color-muted);
+    font-size: 0.95em;
+  }
+
+  .case-study-body :global(a) {
+    color: var(--color-text);
+    text-decoration: underline;
+    text-decoration-color: var(--color-faint);
+    text-underline-offset: 3px;
+    transition: text-decoration-color 0.2s;
+  }
+  .case-study-body :global(a:hover) {
+    text-decoration-color: var(--color-text);
+  }
+
+  .case-study-body :global(code) {
+    font-family: var(--font-mono);
+    font-size: 0.875em;
+    color: var(--color-text);
+    background-color: var(--color-border);
+    padding: 0.1em 0.35em;
+    border-radius: 0.25rem;
+  }
+
+  /* OUTCOME */
+  .case-study-outcome { margin: 4rem 0 0; }
+  .case-study-tech    { margin: 3rem 0 0; }
+
+  .case-study-section-title {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-faint);
+    margin: 0 0 1.5rem;
+  }
+
+  .outcome-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+    gap: 1.5rem 2rem;
+    margin: 0;
+    padding: 0;
+  }
+
+  .outcome-stat {
+    display: flex;
+    flex-direction: column;
+    gap: 0.3rem;
+  }
+
+  .outcome-number {
+    font-family: var(--font-mono);
+    font-size: clamp(1.6rem, 3vw, 2.2rem);
+    font-weight: 700;
+    color: var(--color-text);
+    margin: 0;
+  }
+
+  .outcome-label {
+    font-size: 0.85rem;
+    color: var(--color-muted);
+    margin: 0;
+    line-height: 1.4;
+  }
+
+  .outcome-text {
+    font-size: 1rem;
+    line-height: 1.65;
+    color: var(--color-text);
+    margin: 0;
+    max-width: 42em;
+  }
+
+  /* TECH TAG LIST — reuses .tags base */
+  .case-study-tech-list { margin-top: 0; }
+
+  @media (max-width: 720px) {
+    .case-study { padding: 1rem 1.25rem 3rem; }
+    .case-study-hero { padding: 0.5rem 0 1.5rem; }
+    .case-study-notice { padding: 0.75rem 0.9rem; font-size: 12.5px; }
+    .case-study-body :global(h2) { margin-top: 2.5rem; }
+    .case-study-body :global(h3) { margin-top: 2rem; }
+    .outcome-grid { grid-template-columns: 1fr 1fr; gap: 1rem 1.5rem; }
+  }
+
+  @media (max-width: 460px) {
+    .outcome-grid { grid-template-columns: 1fr; }
+  }
+</style>

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -55,7 +55,7 @@ const data = entry.data;
       <h2 class="case-study-section-title">Outcome</h2>
       {data.outcomeStats && data.outcomeStats.length > 0 && (
         <dl class="outcome-grid">
-          {data.outcomeStats.map((stat) => (
+          {data.outcomeStats.map((stat: { number: string; label: string }) => (
             <div class="outcome-stat">
               <dt class="outcome-number">{stat.number}</dt>
               <dd class="outcome-label">{stat.label}</dd>
@@ -71,7 +71,7 @@ const data = entry.data;
     <section class="case-study-tech">
       <h2 class="case-study-section-title">Tech</h2>
       <ul class="tags case-study-tech-list">
-        {data.tech.map((t) => <li>{t}</li>)}
+        {data.tech.map((t: string) => <li>{t}</li>)}
       </ul>
     </section>
 

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -1,0 +1,58 @@
+import { test, expect } from '@playwright/test';
+
+const cases = [
+  { slug: 'leather',     title: 'Leather Bitcoin Wallet', company: 'Trust Machines' },
+  { slug: 'cryptowatch', title: 'Cryptowatch',            company: 'Kraken' },
+  { slug: 'xapo',        title: 'Xapo',                   company: 'Xapo' },
+  { slug: 'qredo',       title: 'Qredo',                  company: 'Qredo' },
+];
+
+test.describe('Case study pages', () => {
+  for (const { slug, title, company } of cases) {
+    test.describe(`/work/${slug}`, () => {
+      test('loads with correct title', async ({ page }) => {
+        await page.goto(`/work/${slug}/`);
+        await expect(page).toHaveTitle(`${title} | Pete Watters`);
+      });
+
+      test('hero shows company and headline', async ({ page }) => {
+        await page.goto(`/work/${slug}/`);
+        await expect(page.locator('.meta-company')).toHaveText(company);
+        await expect(page.locator('.case-study-headline')).toBeVisible();
+      });
+
+      test('shows confidentiality notice', async ({ page }) => {
+        await page.goto(`/work/${slug}/`);
+        await expect(page.locator('.case-study-notice')).toBeVisible();
+      });
+
+      test('shows Outcome and Tech sections', async ({ page }) => {
+        await page.goto(`/work/${slug}/`);
+        await expect(page.locator('.case-study-outcome')).toBeVisible();
+        await expect(page.locator('.case-study-tech')).toBeVisible();
+      });
+
+      test('back link returns home', async ({ page }) => {
+        await page.goto(`/work/${slug}/`);
+        const back = page.locator('.case-study-back').first();
+        await expect(back).toBeVisible();
+        await back.click();
+        await expect(page).toHaveURL('/');
+      });
+    });
+  }
+
+  test('Leather page shows outcome stat grid (not text)', async ({ page }) => {
+    await page.goto('/work/leather/');
+    await expect(page.locator('.outcome-grid')).toBeVisible();
+    await expect(page.locator('.outcome-stat')).toHaveCount(5);
+  });
+
+  test('stub pages show outcome text (not stat grid)', async ({ page }) => {
+    for (const slug of ['cryptowatch', 'xapo', 'qredo']) {
+      await page.goto(`/work/${slug}/`);
+      await expect(page.locator('.outcome-text')).toBeVisible();
+      await expect(page.locator('.outcome-grid')).toHaveCount(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- New `work` content collection at `src/content/work/` with four entries
- Dynamic route `src/pages/work/[slug].astro` renders each with a shared layout: back link, hero (meta + stat + headline + subtitle), confidentiality notice, markdown body, outcome (stat grid or one-liner), tech tags, back link
- Leather is the full case study — four chapters covering rebrand, monorepo + Panda UI, mobile app, NFT gallery + AI workflow. Outcome rendered as a 5-stat grid
- Cryptowatch, Xapo, Qredo are shorter stubs — each has a hero, notice, two-to-four chapters with 2-3 sentence summaries, and a one-line outcome
- All four pages link `← All work` back to `/`. Once PR #67 (homepage) merges, those links will line up with the case-study cards
- Verb framing aligns with the existing CV: "Worked on as a core team member" / "Managed the end-to-end launch" / "Shipped" — no role-elevating verbs added beyond what's already on `/cv/full-stack/`
- e2e tests cover routing, hero meta, notice, outcome/tech sections, and back link for each of the four pages

## Notes for review
- Confidentiality notices follow a consistent pattern across all four: scope of personal contribution + brand status (open source / no longer active / rebrand / NDA-respecting) + disclaimer that details reflect Pete's experience
- Cryptowatch + Qredo case studies cross-link to your existing blog posts (`/blog/human-readable-ethereum-transactions/`, `/blog/mnemonic-validation/`)
- Stub pages are buildable now but worth more passes once you locate old screenshots
- PR #67 (homepage) and this PR are independent — merge in either order