### PR TITLE
Solana NFT avatar: build-time fetch with fallback

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,13 @@
+# Build-time secrets — set as GitHub Actions secrets in repository settings.
+# These are intentionally NOT prefixed with PUBLIC_ so they stay server-side
+# only and are never bundled into the client JS.
+#
+# Used by src/components/Header.astro to fetch the NFT avatar image URL from
+# the Solana blockchain at build time via the Helius DAS API. If either var
+# is missing or the fetch fails, the build falls back to /img/apple-touch-icon.png.
+
+# Helius API key — get one free at https://www.helius.dev
+HELIUS_KEY=
+
+# Solana NFT mint address (pubkey, ~44 chars base58)
+NFT_MINT=

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
     env:
       CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      HELIUS_KEY: ${{ secrets.HELIUS_KEY }}
+      NFT_MINT: ${{ secrets.NFT_MINT }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,12 +1,55 @@
 ---
 import Nav from './Nav.astro';
+
+const FALLBACK_AVATAR = '/img/apple-touch-icon.png';
+
+const HELIUS_KEY = import.meta.env.HELIUS_KEY;
+const NFT_MINT = import.meta.env.NFT_MINT;
+
+let avatarUrl = FALLBACK_AVATAR;
+let avatarSource: 'fallback' | 'on-chain' = 'fallback';
+
+if (HELIUS_KEY && NFT_MINT) {
+  try {
+    const res = await fetch(`https://mainnet.helius-rpc.com/?api-key=${HELIUS_KEY}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 'nft-avatar',
+        method: 'getAsset',
+        params: { id: NFT_MINT },
+      }),
+    });
+
+    if (res.ok) {
+      const payload = await res.json();
+      const image = payload?.result?.content?.links?.image;
+      if (typeof image === 'string' && image.startsWith('http')) {
+        avatarUrl = image;
+        avatarSource = 'on-chain';
+      }
+    } else {
+      console.warn(`[Header] Helius DAS returned ${res.status} ${res.statusText} — using fallback avatar`);
+    }
+  } catch (err) {
+    console.warn('[Header] Helius DAS fetch failed — using fallback avatar', err);
+  }
+}
 ---
 
 <header>
   <div class="header-inner">
     <div class="header-left">
       <a href="/" class="profile-link">
-        <img src="/img/apple-touch-icon.png" alt="Pete Watters" class="profile-avatar" width="40" height="40" />
+        <img
+          src={avatarUrl}
+          alt="Pete Watters"
+          class="profile-avatar"
+          width="40"
+          height="40"
+          data-avatar-source={avatarSource}
+        />
       </a>
       <h1><a href="/">Pete Watters</a></h1>
     </div>


### PR DESCRIPTION
## Summary
- `src/components/Header.astro` now fetches the NFT image URL from the Solana blockchain at build time via the Helius DAS API (`getAsset`), bakes the URL into the static HTML, and falls back to `/img/apple-touch-icon.png` if env vars are missing or the fetch fails
- `.github/workflows/deploy.yml` adds `HELIUS_KEY` and `NFT_MINT` to the build env, sourced from GitHub Actions secrets — both intentionally **without** the `PUBLIC_` prefix so they stay server-side and never enter the client bundle
- New `.env.example` documents the two variables for future contributors / local dev
- A `data-avatar-source="on-chain"|"fallback"` attribute is set on the avatar `<img>` so the source is auditable in DOM inspection

## Setup required before merge
You need to add two secrets in repo settings → Secrets and variables → Actions → New repository secret:

| Secret | Value |
|---|---|
| `HELIUS_KEY` | Your Helius API key (regenerate the one from chat history first — see security note below) |
| `NFT_MINT` | `2zhh8BLg1HXT1EzoucDuzm8rkpiaFq3uiT3KniTyMw9u` (derived from the mint tx earlier) |

After secrets are in place, the next push to `main` will rebuild and the avatar will pull from on-chain. If you merge without setting the secrets, the build succeeds and the existing fallback PNG keeps being served — no regression.

## Security notes
- The Helius key you shared in chat is now in the conversation transcript. **Rotate it** at helius.dev before adding the new value as a GitHub secret. Free to regenerate; the brief doesn't depend on this specific key.
- Build-time fetch was chosen over runtime/client-side fetch specifically so the key never reaches the browser. GitHub Actions secrets are not logged unless explicitly printed, and Astro non-`PUBLIC_` vars never enter the JS bundle.
- The fetched image URL is on a public CDN (storage.googleapis.com/reavers-56900) and isn't sensitive — it's already public via Solana Explorer.

## Verified
- Build without env vars → fallback PNG renders, `data-avatar-source="fallback"`. No regression.
- Helius `getAsset` against the derived mint returns a valid image URL for "Trippin' Ape Tribe #3914". Once secrets are set in Actions, production will swap to that URL automatically.