### PR TITLE
Add dev branch staging deploy to CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,17 @@
+# Deploys to Cloudflare Pages.
+#
+# Branch strategy:
+#   main → production (petewatters.ie)
+#   dev  → stable staging at dev.portfolio.pages.dev
+#   PR   → ephemeral per-PR preview at <branch>.portfolio.pages.dev
+#
+# Workflow: feature branches → PR into dev → merge dev → main when releasing.
+
 name: Deploy
 
 on:
   push:
-    branches: [main]
+    branches: [main, dev]
   pull_request:
 
 jobs:
@@ -29,8 +38,13 @@ jobs:
         id: deploy
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
+            # Ephemeral per-PR preview
             DEPLOY_OUTPUT=$(npx wrangler pages deploy dist --project-name=portfolio --branch="${{ github.head_ref }}" --commit-dirty=true 2>&1)
+          elif [ "${{ github.ref_name }}" = "dev" ]; then
+            # Stable staging deploy: dev.portfolio.pages.dev
+            DEPLOY_OUTPUT=$(npx wrangler pages deploy dist --project-name=portfolio --branch=dev --commit-dirty=true 2>&1)
           else
+            # Production (main branch)
             DEPLOY_OUTPUT=$(npx wrangler pages deploy dist --project-name=portfolio --commit-dirty=true 2>&1)
           fi
           echo "$DEPLOY_OUTPUT"


### PR DESCRIPTION
## Summary
- Workflow now handles three deploy targets:
  - `main` push → production at petewatters.ie
  - `dev` push → stable staging at `dev.portfolio.pages.dev`
  - PR → ephemeral per-branch preview at `<branch>.portfolio.pages.dev`
- Added a header comment in the YAML documenting the branch strategy so it's discoverable in code
- Existing PR preview logic and comment-on-PR behaviour unchanged

## Bootstrapping the new workflow
After this merges to main, here's the sequence to flip on:

1. **Create the `dev` branch** off main:
   ```bash
   git checkout main && git pull
   git checkout -b dev && git push -u origin dev
   ```
   The first push to dev triggers a build and creates `https://dev.portfolio.pages.dev`.

2. **Enable branch protection on main** in repo settings:
   - https://github.com/pete-watters/portfolio-pwa/settings/branches → Add branch protection rule
   - Branch name pattern: `main`
   - Recommended for a solo dev:
     - ☑ Require a pull request before merging (no direct push)
     - ☐ Require approvals (set to 0 — you can't approve your own PR)
     - ☑ Require status checks to pass before merging → select `deploy`
     - ☑ Do not allow bypassing the above settings (enforce on admins)
     - ☑ Restrict who can push (leave empty — combined with PR requirement, this stops direct main pushes including your own)
     - ☐ Allow force pushes (off)
     - ☐ Allow deletions (off)

3. **Rebase the four open feature PRs** to target dev instead of main:
   - PR #67 (homepage), #68 (case studies), #69 (CV landing), #70 (NFT avatar)
   - GitHub UI: each PR → Edit → change base branch from `main` to `dev`
   - No code rebase needed unless dev has diverged

Once the four PRs are merged into dev, you'll have a full integration preview at `dev.portfolio.pages.dev` to eyeball before promoting. When ready, open a single `dev → main` PR for the production release.

## Notes
- This PR intentionally targets `main` since branch protection isn't on yet and `dev` doesn't exist. Future workflow changes will follow the same dev-first flow.
- Doesn't add the `HELIUS_KEY` / `NFT_MINT` env vars — PR #70 owns those. The two PRs touch different parts of `deploy.yml` and shouldn't conflict.