### PR TITLE
Add MIT license and tidy README ahead of going public

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Pete Watters
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -38,10 +38,14 @@ src/
     blog/        # Blog posts (markdown)
     cv/          # CV content collection
   layouts/       # Astro layouts (BaseLayout, CvLayout)
-  pages/         # Routes (/, /about, /blog, /cv)
+  pages/         # Routes (/, /blog, /cv)
   components/    # Astro components
 public/
   docs/          # PDFs (thesis, certifications)
 tests/
   e2e/           # Playwright tests
 ```
+
+## License
+
+MIT — see [LICENSE](./LICENSE).


### PR DESCRIPTION
## Summary
- Add `LICENSE` (MIT, copyright 2026 Pete Watters) — required for the free CodeRabbit OSS tier and for being a good open-source citizen
- Fix `README.md` route list: drop reference to non-existent `/about`, add a License section

## Why MIT
- Permissive, OSI-approved, ~50% of OSS uses it. Unlocks the free CodeRabbit tier
- Lets anyone read, fork, or borrow snippets without obligation, which is what a portfolio actually wants
- Copyright still belongs to you — MIT only governs reuse, not authorship

## Targets main directly
This is the last main-targeting PR before branch protection goes on. After this merges and you flip protection on `main`, everything else (feature work, content updates, etc.) flows through `dev` first per the workflow established in #71.