### PR TITLE
docs: add CONTRIBUTING, SKILLS, and PR template; gitignore .private/

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,13 @@
+## Summary
+
+-
+
+## Linked issue
+
+<!-- Pick one of the following and delete the others -->
+
+Closes #
+
+<!-- or, if no issue is being tackled, replace with one of: -->
+<!-- Type: bug fix (ad-hoc, no linked issue) -->
+<!-- Type: chore / cleanup (no linked issue) -->

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# private working notes — never push
+.private/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,192 @@
+# Contributing
+
+How work flows through this repo. This is a personal portfolio maintained
+by Pete Watters; conventions still matter so the repo behaves consistently
+with other repos in the same workflow.
+
+If you're an external contributor opening a PR, please read this first.
+
+---
+
+## Workstream prefix on issue titles
+
+Issues should be prefixed with `[XX-NN]` where:
+
+- `XX` is the two-letter workstream code (e.g. `HP` for homepage, `CV` for
+  CV section, `BL` for blog, `CI` for CI/deploy, `WK` for case-studies
+  workstream)
+- `NN` is the sequence within that workstream
+
+Example: `[HP-04] Add view transitions between homepage and case studies`
+
+Each workstream prefix maps 1:1 to:
+
+- A workstream label on the issue (`ws: homepage`, `ws: cv`, etc.)
+- An RFC in `docs/rfcs/` describing the scope, motivation, and acceptance
+  criteria for that workstream (when the scope warrants one)
+
+This convention is aspirational for this repo as of 2026-05 — `docs/rfcs/`
+doesn't exist yet. The first non-trivial workstream that ships should
+create it.
+
+---
+
+## Labels
+
+Issues and PRs are tagged across four axes plus the existing default
+stock labels.
+
+### Area (per major surface or package)
+
+- `area: homepage`
+- `area: cv`
+- `area: blog`
+- `area: work` (case studies under `/work/<slug>/`)
+- `area: ci`
+- `area: infra` (deploy, secrets, Cloudflare Pages config)
+- `area: docs`
+
+### Workstream (per RFC)
+
+Added as workstreams are formalised. Examples:
+
+- `ws: homepage-redesign-may-2026`
+- `ws: nft-avatar`
+- `ws: dev-staging-workflow`
+
+### Size
+
+Rough effort estimate. Decide based on diff size and review surface.
+
+- `size: s` — a single file or under ~50 changed lines
+- `size: m` — several files or up to ~500 changed lines
+- `size: l` — broad surface, >500 changed lines, or coordinated multi-PR work
+
+### Status
+
+State signals that change a triage decision.
+
+- `status: blocked` — waiting on something external
+- `status: quick-win` — small, well-scoped, can be picked up immediately
+- `status: in-review` — open PR exists
+
+### Stock (already on the repo)
+
+`bug`, `enhancement`, `documentation`, `question`, `incident`,
+`good first issue`, `help wanted`, `wontfix`, `dependencies`.
+
+---
+
+## Branching — GitFlow
+
+| Branch | Role | Auto-deploys to |
+|---|---|---|
+| `main` | Production. Protected. Squash-merge only from PRs targeting `main`. | `petewatters.ie` |
+| `dev` | Staging / integration. Light protection (block force-pushes + deletions). Feature PRs land here. | `dev.portfolio.pages.dev` |
+| `feat/*`, `fix/*`, `chore/*`, `ci/*`, `docs/*` | Short-lived working branches. PR into `dev`. | Ephemeral per-PR preview |
+| `release/*` | Optional, only used when batching dev → main needs review surface | n/a |
+
+Release flow: when `dev` is stable, open a single `dev → main` PR. Merging
+that promotes to production. Tag the resulting commit on main with the
+release version where applicable.
+
+CI is documented in [`.github/workflows/deploy.yml`](.github/workflows/deploy.yml)
+— the header comment describes the deploy targets.
+
+---
+
+## PR hygiene
+
+### Title — conventional commits
+
+`type(scope): subject`
+
+Types in active use: `feat`, `fix`, `chore`, `ci`, `docs`, `refactor`, `test`.
+Scope is optional but encouraged for cross-area work.
+
+Examples from this repo's history:
+
+- `feat(homepage): hero, logo strip, case studies, timeline`
+- `feat(work): four case study pages at /work/<slug>/`
+- `ci: add dev branch staging deploy alongside main and PR previews`
+- `chore: harden .gitignore to catch all .env variants`
+
+No `feat:` for content-only changes (use `chore(blog):` or `docs:`).
+Subject is imperative mood, no trailing period.
+
+### Body — use the template
+
+The PR body is auto-populated from
+[`.github/pull_request_template.md`](.github/pull_request_template.md).
+Required:
+
+- A `## Summary` bullet list explaining what changed and why
+- A `## Linked issue` block with one of: `Closes #N`, `Refs #N`, or a
+  `Type:` tag for issueless work (`bug fix`, `chore / cleanup`)
+
+No "test plan" section, no Claude credit, no Co-Authored-By unless the
+collaborator is a real person.
+
+### Post-open routine
+
+When you open a PR, post a status comment that opens with `@<maintainer>`
+and uses these sections (delete sections that don't apply):
+
+```md
+@pete-watters
+
+## Shipped
+- <what's done in this PR>
+
+## Pending
+- <what's still in flight / known follow-up>
+
+## Verification
+- <how to confirm it works — preview URL, test command, manual check>
+```
+
+The Cloudflare Pages preview URL will land as its own comment from the
+deploy workflow — link to it from the Verification section.
+
+---
+
+## Incidents
+
+For prod incidents (broken deploy, regression, security issue):
+
+1. **Open an issue first**, labelled `incident` and the relevant `area:`
+   label. Title prefix `[INC-NN]`. Description: timeline, impact, scope.
+2. **Open a fix PR that `Closes #N`**, targeting `dev` (or `main` directly
+   if production is broken right now — note the bypass in the PR body and
+   open a follow-up PR backporting the fix to dev).
+3. After resolution, edit the issue with a post-mortem: root cause,
+   detection, response, prevention.
+
+---
+
+## Local development
+
+```bash
+npm install
+npm run dev          # Start Astro dev server
+npm run build        # Production build
+npm run preview      # Preview production build locally
+```
+
+Tests + lint:
+
+```bash
+npm run lint                # ESLint
+npm run check               # Astro type-check
+npm run test:unit           # Vitest
+npm run test:e2e:headless   # Playwright chromium
+```
+
+---
+
+## Verified commits
+
+The `main` branch ruleset requires signed commits. GitHub squash-merges
+satisfy this automatically. Local commits should be signed (GPG or SSH) so
+they appear Verified on feature branches too — see GitHub's docs on
+[signing commits](https://docs.github.com/en/authentication/managing-commit-signature-verification).

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,182 @@
+# Animation Skill — petewatters.ie
+
+How animations are decided, written, and reviewed in this project. The
+patterns documented here match what's actually shipped in the codebase
+today (see `src/pages/index.astro` for live examples).
+
+## Philosophy
+
+The site's visual identity is restrained: system fonts, a monochrome
+palette with one orange accent (`#F7931A`), generous whitespace, no
+visual noise. Animation supports that — it does not perform.
+
+The bar is: *every animation has to earn its place*. If you can remove
+the animation and the UX is unchanged, remove it.
+
+Concretely:
+
+- **CSS-first.** No animation libraries. No `framer-motion`, no `gsap`,
+  no `react-spring`. The current stack is plain CSS keyframes +
+  IntersectionObserver. If a future Astro upgrade lands View Transitions,
+  use the platform feature, not a wrapper.
+- **Performance-first.** Animate only `opacity`, `transform`, `filter`,
+  and `box-shadow`. Never animate layout properties (`width`, `height`,
+  `top`, `left`, `padding`, `margin`) — they trigger paint/layout and
+  drop frames on mobile.
+- **Accessibility-first.** Every animation has a
+  `prefers-reduced-motion: reduce` fallback that disables it.
+
+---
+
+## Hard rules
+
+| Rule | Value | Why |
+|---|---|---|
+| Duration — micro (hover, focus) | **0.25 – 0.3s** | Below 0.2s feels instant (no perceived motion); above 0.35s feels sluggish for a hover |
+| Duration — medium (mount, reveal) | **0.5 – 0.6s** | Long enough to read the motion, short enough to not delay reading |
+| Duration — ambient loops (pulse, etc) | **2 – 3s** | Slow enough to register as "background life", not as something demanding attention |
+| Duration — hard cap on one-shots | **0.7s** | Above this, the user is waiting for animation to finish before they can interact |
+| Easing — default | **`cubic-bezier(0.16, 1, 0.3, 1)`** | Smooth ease-out. Available in CSS as `var(--ease-out-soft)`. Used for enters, hovers, reveals |
+| Easing — loops | **`ease-in-out`** | Natural for back-and-forth (pulse) |
+| Properties allowed | `opacity`, `transform`, `filter`, `box-shadow` | GPU-composited; no layout cost |
+| `prefers-reduced-motion` | **Required** on every animation | Honour user setting |
+| No JS animation libraries | Pure CSS + `IntersectionObserver` | Bundle size, no runtime overhead |
+
+---
+
+## When to animate — yes
+
+- **State transitions** — hover, focus, active. Subtle feedback that the
+  element is interactive.
+- **Mount / enter** — first appearance of content (page load fade-up,
+  scroll-reveal fade-in).
+- **Feedback** — loading indicators, success states, "saved" toasts.
+- **Ambient status** — slowly pulsing dot on availability badge signals
+  "this is live data" without demanding attention.
+
+## When to animate — no
+
+- **Anything users see more than ~100×/day.** The first 10 times it's
+  delightful; the 100th it's a tax. Examples: nav links, the cursor
+  itself, scrollbar behaviour.
+- **Anything on the critical reading path.** Don't animate paragraph text
+  appearing while the user is mid-sentence.
+- **Decorative animation that doesn't serve UX.** Background particles,
+  random floaters, "look at me" effects.
+- **Anything that delays interactivity by more than 0.3s.** If the user
+  has to wait for your animation to finish before they can click, the
+  animation is too slow.
+
+---
+
+## Named primitives in this project
+
+These already exist. Reuse before inventing.
+
+### `--ease-out-soft`
+
+```css
+.homepage {
+  --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+}
+```
+
+The default easing token. Use everywhere unless you have a documented
+reason not to.
+
+### `data-reveal` — scroll-triggered fade-up
+
+```html
+<element data-reveal>...</element>
+```
+
+```css
+[data-reveal] {
+  opacity: 0;
+  transform: translateY(12px);
+  transition: opacity 0.6s var(--ease-out-soft),
+              transform 0.6s var(--ease-out-soft);
+}
+[data-reveal].is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+```
+
+Wired up via `IntersectionObserver` in the inline script in
+`src/pages/index.astro`. Supports per-group staggering via `data-stagger`
+attribute (set in JS).
+
+### `@keyframes badge-pulse` — ambient status indicator
+
+```css
+.badge-dot {
+  animation: badge-pulse 2.5s ease-in-out infinite;
+}
+@keyframes badge-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(247, 147, 26, 0.4); }
+  50%      { opacity: 0.6; box-shadow: 0 0 0 6px rgba(247, 147, 26, 0); }
+}
+```
+
+Used on the availability badge dot. The ring expands outward then fades
+— signals "live" without flashing.
+
+### `@keyframes hero-word-up` — staggered enter
+
+```css
+@keyframes hero-word-up {
+  to { opacity: 1; transform: translateY(0); }
+}
+```
+
+Per-element animation delays drive the stagger
+(`animation-delay: 0.35s` … `0.75s`).
+
+### Hover transforms
+
+Established pattern: `translateY(-2px)` to `translateY(-3px)` lift on
+cards, `translateX(4px)` on arrow icons inside links. Always paired with
+a colour or border transition for parallel feedback.
+
+---
+
+## Checklist for adding a new animation
+
+Before merging, confirm each:
+
+1. [ ] **UX purpose** — what does this animation tell the user that the
+       absence wouldn't? If you can't answer in one sentence, don't add it.
+2. [ ] **Duration ≤ 0.7s** for one-shots? Loops between 2–3s? If not,
+       justify in the PR description.
+3. [ ] **Easing** is `var(--ease-out-soft)`, or there's a documented
+       reason for a different curve (e.g. `ease-in-out` for a loop).
+4. [ ] **Properties** are limited to `opacity`, `transform`, `filter`,
+       `box-shadow`. No layout properties.
+5. [ ] **`prefers-reduced-motion: reduce`** fallback in place — animation
+       or transition disabled, element rendered in its final state.
+6. [ ] **Tested on a low-end device** (or DevTools 6× CPU throttle) — no
+       dropped frames on the animation.
+7. [ ] **Add a visual regression scenario** — *aspirational, no infra yet.*
+       When visual regression infrastructure lands (Playwright snapshot
+       or similar), add a scenario covering the new animation's start
+       and end states. Until then, note "no visual regression coverage"
+       in the PR.
+
+---
+
+## Forward-looking — what isn't here yet
+
+This project deliberately ships without:
+
+- A JS animation library (no `framer-motion` etc.)
+- An animation testing framework (no visual regression)
+- View Transitions (Astro supports them but they're not adopted here)
+- Page-level scroll-based effects (parallax, sticky-section transitions)
+
+If any of these become useful, add a new section to this file documenting
+the decision, the primitive added, and the rule for when to reach for it.
+
+The hardest constraint to maintain over time is **restraint** — every
+contributor will be tempted to add "just one more cool animation".
+This document exists to make that conversation explicit.


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` — GitFlow branching (`main`/`dev`/feature), 4-axis labels (area / workstream / size / status) on top of stock labels, conventional-commit PR titles, post-open status-comment routine, incidents-first flow. Specific to this repo's current state — sections about RFCs and multi-axis labels are marked aspirational until the first workstream creates them.
- Add `SKILLS.md` — animation conventions grounded in the actual patterns shipped in PR #67. Documents the `--ease-out-soft` token, `data-reveal` IntersectionObserver pattern, `badge-pulse` ambient indicator, hero word stagger. Hard rules on duration / easing / properties / reduced-motion. 7-item checklist for new animations.
- Add `.github/pull_request_template.md` — exact body from the convention.
- Add `.private/` to `.gitignore` for private working notes and Claude skills that should never push.

This PR is itself the proof the docs work — it follows the conventional-commits title format, uses the new PR template, targets `dev` per the GitFlow rule.

## Linked issue

Type: chore / cleanup (no linked issue)