### PR TITLE
ci: add update-visual-baselines workflow

### DIFF
--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -1,0 +1,53 @@
+# Bootstrap or refresh visual-regression baselines on Linux CI, where the
+# main `Visual Regression` workflow runs. Snapshots are platform-specific —
+# Mac-generated PNGs won't match Linux Chromium output, so they must be
+# generated in CI to be the canonical baseline.
+#
+# Trigger manually from the Actions tab → "Update visual baselines" →
+# Run workflow → pick the branch. The job runs Playwright with
+# --update-snapshots, then commits and pushes any new/changed PNGs in
+# e2e/__screenshots__ back to the branch.
+#
+# Use when:
+#   - First-run bootstrap (no baselines exist yet)
+#   - Intentional design change — current renders are correct, baselines stale
+
+name: Update visual baselines
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-baselines:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npm run build
+      - run: npx bddgen --config playwright.bdd.config.ts
+      - name: Regenerate snapshots
+        run: npx playwright test --config playwright.bdd.config.ts --update-snapshots
+        env:
+          CI: 'true'
+      - name: Commit + push updated baselines
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add e2e/__screenshots__
+          if git diff --staged --quiet; then
+            echo "No baseline changes."
+          else
+            git commit -m "chore(e2e): refresh visual-regression baselines [skip ci]"
+            git push
+          fi


### PR DESCRIPTION
## Summary

- Adds \`.github/workflows/update-visual-baselines.yml\` — a \`workflow_dispatch\`-only workflow that regenerates visual regression baselines on Linux CI and commits them back to whatever branch you triggered it from
- Needs to live on \`main\` because GitHub requires \`workflow_dispatch\` workflows to exist on the default branch to be invokable
- Doesn't run on push or PR — only when manually triggered from the Actions tab

## Why this is targeting main directly

Same exception as #72 and #73 — meta-CI bootstrap that can't go through dev because GitHub requires the workflow file on the default branch before any branch can dispatch it. Subsequent CI changes will flow through dev per the normal workflow.

## How to use after merge

Actions tab → "Update visual baselines" → Run workflow → pick the branch (e.g. \`feat/e2e-visual-regression\` for the first PR #75 bootstrap, or any future branch with baseline drift). The workflow runs \`--update-snapshots\`, commits any new/changed PNGs in \`e2e/__screenshots__\`, and pushes back. The \`[skip ci]\` in the commit message prevents an infinite re-trigger.

## Linked issue

Type: chore / cleanup (no linked issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added a new GitHub Actions workflow to manage visual regression test baselines. The workflow can be manually triggered to refresh visual snapshots, handles project builds and dependency installations, and automatically commits and pushes changes back to the branch when updates are detected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pete-watters/portfolio-pwa/pull/78?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->