### PR TITLE
feat(hero-header): sticky header with availability + nav, drop hero duplicate, add contact section

### DIFF
--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -1,0 +1,47 @@
+---
+import { SOCIAL } from '../consts';
+
+// Public-facing alias — set up forwarding (hello@petewatters.ie → real inbox)
+// in DNS/email provider before site goes live with this section.
+const EMAIL = 'hello@petewatters.ie';
+---
+
+<section class="contact-section" id="contact" aria-labelledby="contact-label">
+  <p class="section-label" id="contact-label">Contact</p>
+  <p class="contact-bio">
+    Available from September 2026 for senior frontend or full-stack engineering work.
+    Ping me on <a href={`mailto:${EMAIL}`}>{EMAIL}</a>, or find me on
+    <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer">GitHub</a>,
+    <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer">X</a>,
+    or <a href={SOCIAL.STACKOVERFLOW} target="_blank" rel="noopener noreferrer">Stack Overflow</a>.
+  </p>
+  <!-- PGP key fingerprint will live here once hardware-backed GPG is set up (see issue tracking) -->
+</section>
+
+<style>
+  .contact-section {
+    --ease-hover: ease;
+    text-align: left;
+    margin-top: 2rem;
+  }
+
+  .contact-bio {
+    font-size: 1.05rem;
+    line-height: 1.7;
+    color: var(--color-text);
+    max-width: 38em;
+    margin: 0.75rem 0 0;
+  }
+
+  .contact-bio a {
+    color: var(--color-text);
+    text-decoration: underline;
+    text-decoration-color: var(--color-faint);
+    text-underline-offset: 3px;
+    transition: text-decoration-color 0.2s ease;
+  }
+
+  .contact-bio a:hover {
+    text-decoration-color: var(--color-text);
+  }
+</style>

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -38,23 +38,60 @@ if (HELIUS_KEY && NFT_MINT) {
 }
 ---
 
-<header>
+<header class="site-header">
   <div class="header-inner">
-    <div class="header-left">
+    <div class="header-brand">
       <a href="/" class="profile-link">
         <img
           src={avatarUrl}
           alt="Pete Watters"
           class="profile-avatar"
-          width="40"
-          height="40"
+          width="36"
+          height="36"
           data-avatar-source={avatarSource}
         />
       </a>
       <h1><a href="/">Pete Watters</a></h1>
     </div>
-    <div class="header-right">
-      <Nav />
+
+    <Nav />
+
+    <div class="header-end">
+      <a class="header-availability" href="/#contact" aria-label="Available September 2026 — open to roles">
+        <span class="header-availability-dot" aria-hidden="true"></span>
+        <span class="header-availability-text">Available Sep 2026</span>
+      </a>
+
+      <button
+        class="nav-toggle"
+        type="button"
+        aria-label="Toggle navigation"
+        aria-expanded="false"
+        aria-controls="primary-nav"
+      >
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+        <span class="nav-toggle-bar" aria-hidden="true"></span>
+      </button>
     </div>
   </div>
 </header>
+
+<script>
+  const toggle = document.querySelector<HTMLButtonElement>('.nav-toggle');
+  const nav = document.querySelector<HTMLElement>('header.site-header nav.primary-nav');
+
+  toggle?.addEventListener('click', () => {
+    const expanded = toggle.getAttribute('aria-expanded') === 'true';
+    toggle.setAttribute('aria-expanded', String(!expanded));
+    nav?.classList.toggle('is-open', !expanded);
+  });
+
+  // Close mobile nav when a link is tapped
+  nav?.querySelectorAll('a').forEach((link) => {
+    link.addEventListener('click', () => {
+      toggle?.setAttribute('aria-expanded', 'false');
+      nav?.classList.remove('is-open');
+    });
+  });
+</script>

--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,7 +1,15 @@
 ---
-import SocialMedia from './SocialMedia.astro';
+const links = [
+  { href: '/#work', label: 'Work' },
+  { href: '/blog', label: 'Blog' },
+  { href: '/cv/', label: 'CV' },
+];
 ---
 
-<nav>
-  <SocialMedia />
+<nav class="primary-nav" aria-label="Primary">
+  <ul>
+    {links.map((link) => (
+      <li><a href={link.href}>{link.label}</a></li>
+    ))}
+  </ul>
 </nav>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,16 +1,12 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import ContactSection from '../components/ContactSection.astro';
 ---
 
 <BaseLayout>
   <article class="homepage">
 
     <section class="hero">
-      <span class="availability-badge" data-reveal>
-        <span class="badge-dot" aria-hidden="true"></span>
-        Available September 2026
-      </span>
-      <h2 class="hero-name" data-reveal>Pete Watters</h2>
       <p class="hero-words" aria-label="Builder, Engineer, Shipper">
         <span class="hero-word hero-word--accent">Builder</span>
         <span class="hero-word-sep" aria-hidden="true">·</span>
@@ -38,7 +34,7 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       </ul>
     </section>
 
-    <section class="case-studies">
+    <section class="case-studies" id="work">
       <p class="section-label">Selected work</p>
 
       <article class="case-card" data-reveal>
@@ -263,6 +259,8 @@ import BaseLayout from '../layouts/BaseLayout.astro';
         </li>
       </ol>
     </section>
+
+    <ContactSection />
 
   </article>
 </BaseLayout>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -111,32 +111,186 @@ main {
   text-align: center;
 }
 
-header {
-  padding: 1rem;
-  background-color: var(--color-dark);
+/* Site header — sticky, full-width dark bar */
+header.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  padding: 0.6rem 1rem;
+  background-color: rgba(43, 43, 43, 0.92);
+  backdrop-filter: saturate(180%) blur(8px);
+  -webkit-backdrop-filter: saturate(180%) blur(8px);
   color: white;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+}
+
+/* Fallback for browsers without backdrop-filter */
+@supports not (backdrop-filter: blur(8px)) {
+  header.site-header { background-color: var(--color-dark); }
 }
 
 .header-inner {
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  max-width: 680px;
+  gap: 1.25rem;
+  max-width: 1080px;
   margin: 0 auto;
 }
 
-.header-left {
+.header-brand {
   display: flex;
   align-items: center;
   gap: 0.5rem;
   min-width: 0;
 }
 
+.header-end {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  margin-left: auto;
+}
+
 header h1 {
   margin: 0;
   text-align: left;
-  font-size: clamp(1.2rem, 4vw, 2.2rem);
+  font-size: clamp(1.05rem, 3vw, 1.6rem);
   white-space: nowrap;
+}
+
+/* Availability badge embedded in the header */
+.header-availability {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.05em;
+  color: rgba(255, 255, 255, 0.7);
+  background: rgba(247, 147, 26, 0.08);
+  border: 1px solid rgba(247, 147, 26, 0.35);
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  text-decoration: none;
+  transition: background-color 0.25s ease, color 0.25s ease;
+}
+
+.header-availability:hover {
+  background: rgba(247, 147, 26, 0.16);
+  color: #fff;
+}
+
+.header-availability-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #F7931A;
+  animation: header-badge-pulse 2.5s ease-in-out infinite;
+}
+
+@keyframes header-badge-pulse {
+  0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(247, 147, 26, 0.4); }
+  50%      { opacity: 0.6; box-shadow: 0 0 0 4px rgba(247, 147, 26, 0); }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .header-availability-dot { animation: none; }
+}
+
+/* Primary nav links */
+.primary-nav ul {
+  list-style: none;
+  display: flex;
+  gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.primary-nav a {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  letter-spacing: 0.04em;
+  color: rgba(255, 255, 255, 0.78);
+  text-decoration: none;
+  padding: 0.25rem 0;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
+}
+
+.primary-nav a:hover {
+  color: #fff;
+  border-bottom-color: rgba(255, 255, 255, 0.4);
+}
+
+/* Hamburger toggle — hidden on desktop, visible on mobile */
+.nav-toggle {
+  display: none;
+  flex-direction: column;
+  justify-content: space-between;
+  width: 24px;
+  height: 18px;
+  padding: 0;
+  background: transparent;
+  border: none;
+  cursor: pointer;
+}
+
+.nav-toggle-bar {
+  display: block;
+  width: 100%;
+  height: 2px;
+  background: white;
+  border-radius: 1px;
+  transition: transform 0.25s ease, opacity 0.25s ease;
+}
+
+.nav-toggle[aria-expanded='true'] .nav-toggle-bar:nth-child(1) {
+  transform: translateY(8px) rotate(45deg);
+}
+.nav-toggle[aria-expanded='true'] .nav-toggle-bar:nth-child(2) {
+  opacity: 0;
+}
+.nav-toggle[aria-expanded='true'] .nav-toggle-bar:nth-child(3) {
+  transform: translateY(-8px) rotate(-45deg);
+}
+
+@media (max-width: 680px) {
+  .header-inner { gap: 0.6rem; }
+  .header-availability-text { display: none; }
+  .header-availability { padding: 0.3rem 0.45rem; }
+
+  .nav-toggle { display: flex; }
+
+  .primary-nav {
+    position: absolute;
+    top: 100%;
+    left: 0;
+    right: 0;
+    background: var(--color-dark);
+    padding: 0.5rem 1rem 1rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.06);
+    transform: translateY(-8px);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity 0.2s ease, transform 0.2s ease;
+  }
+
+  .primary-nav.is-open {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  .primary-nav ul {
+    flex-direction: column;
+    gap: 0.85rem;
+    max-width: 1080px;
+    margin: 0 auto;
+  }
+
+  .primary-nav a {
+    font-size: 15px;
+  }
 }
 
 /* Breadcrumbs — standalone nav on blog pages */
@@ -167,12 +321,6 @@ header h1 {
   color: var(--color-faint);
 }
 
-.header-right {
-  display: flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
 .profile-avatar {
   width: 36px;
   height: 36px;
@@ -187,27 +335,6 @@ header h1 {
 
 .profile-link:hover {
   text-decoration: none;
-}
-
-nav {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.5rem;
-}
-
-nav a {
-  font-size: clamp(0.9rem, 2vw, 1.25rem);
-  text-decoration: none;
-}
-
-nav ul {
-  list-style-type: none;
-  display: inline-flex;
-}
-
-nav ul li {
-  margin: 0 1rem;
 }
 
 article {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -6,23 +6,36 @@ test.describe('Home page', () => {
     await expect(page).toHaveTitle('Pete Watters');
   });
 
-  test('hero shows availability badge', async ({ page }) => {
+  test('header shows availability badge (not hero)', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.availability-badge')).toContainText('Available September 2026');
+    await expect(page.locator('.header-availability')).toContainText('Available Sep 2026');
+    // Hero-scale availability badge is gone — should not exist
+    await expect(page.locator('.hero .availability-badge')).toHaveCount(0);
   });
 
-  test('hero shows name and the three words', async ({ page }) => {
+  test('header has the primary nav links', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.hero-name')).toHaveText('Pete Watters');
+    const links = page.locator('header.site-header .primary-nav a');
+    await expect(links).toHaveCount(3);
+    await expect(links.nth(0)).toHaveText('Work');
+    await expect(links.nth(1)).toHaveText('Blog');
+    await expect(links.nth(2)).toHaveText('CV');
+  });
+
+  test('hero no longer duplicates the Pete Watters wordmark', async ({ page }) => {
+    await page.goto('/');
+    // .hero-name was removed; the header h1 a is the only wordmark
+    await expect(page.locator('.hero-name')).toHaveCount(0);
+    await expect(page.locator('header.site-header h1 a')).toHaveText('Pete Watters');
+  });
+
+  test('hero shows the three words, sub-tagline and bio', async ({ page }) => {
+    await page.goto('/');
     const words = page.locator('.hero-word');
     await expect(words).toHaveCount(3);
     await expect(words.nth(0)).toHaveText('Builder');
     await expect(words.nth(1)).toHaveText('Engineer');
     await expect(words.nth(2)).toHaveText('Shipper');
-  });
-
-  test('hero shows sub-tagline and bio', async ({ page }) => {
-    await page.goto('/');
     await expect(page.locator('.hero-subtagline')).toContainText('PLAN IT');
     await expect(page.locator('.hero-bio')).toContainText('crypto products');
   });
@@ -33,6 +46,11 @@ test.describe('Home page', () => {
     await expect(items).toHaveCount(6);
     await expect(items.nth(0)).toHaveText('Kraken');
     await expect(items.nth(5)).toHaveText('Qredo');
+  });
+
+  test('case studies section has id="work" so /#work anchor scrolls correctly', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('section.case-studies#work')).toBeVisible();
   });
 
   test('shows four case study cards', async ({ page }) => {
@@ -56,5 +74,20 @@ test.describe('Home page', () => {
     await expect(rows).toHaveCount(9);
     await expect(rows.first().locator('.timeline-company')).toHaveText('Trust Machines');
     await expect(rows.last().locator('.timeline-company')).toHaveText('Earlier');
+  });
+
+  test('contact section renders with email + social links', async ({ page }) => {
+    await page.goto('/');
+    const contact = page.locator('section.contact-section#contact');
+    await expect(contact).toBeVisible();
+    await expect(contact.locator('a[href^="mailto:"]')).toBeVisible();
+    await expect(contact.locator('a[href*="github.com/pete-watters"]')).toBeVisible();
+    await expect(contact.locator('a[href*="x.com/petew_btc"]')).toBeVisible();
+  });
+
+  test('header has no social icons (they moved to contact section)', async ({ page }) => {
+    await page.goto('/');
+    await expect(page.locator('header.site-header a[href*="github.com"]')).toHaveCount(0);
+    await expect(page.locator('header.site-header a[href*="x.com"]')).toHaveCount(0);
   });
 });


### PR DESCRIPTION
## Summary

Closes #80.

**Header**
- Availability badge moved from hero into the header (right side, smaller pill, same orange pulsing dot)
- Header is now sticky with backdrop blur and a subtle bottom border
- New primary nav: \`Work\` / \`Blog\` / \`CV\` (with hamburger toggle on mobile ≤680px)
- Social icons removed — they live in the new contact section now

**Hero**
- Removed the duplicate \`<h2>Pete Watters</h2>\` from the hero body — the header h1 a is the canonical wordmark, so the hero leads with \`Builder · Engineer · Shipper\` directly
- Kept the existing hero-words staggered fade-up, sub-tagline, bio

**Contact section (new)**
- New \`ContactSection.astro\` component, rendered at the bottom of the homepage with \`id="contact"\`
- Paul Miller-style inline pattern: bio + email + GitHub + X + Stack Overflow
- Email is the **alias \`hello@petewatters.ie\`** — needs DNS forwarding set up before prod (decision flagged for you)
- Reserved space (HTML comment) for PGP fingerprint once hardware-backed GPG is in place

**Anchors**
- Added \`id="work"\` to the case-studies section so the header nav's \`/#work\` link scrolls to it

## Things I deliberately did NOT do

- **Builder · Engineer · Shipper graphic glyphs** — Pete asked to investigate "cool design options" inspired by benbrk.com. That's design-direction territory, not safe to make a unilateral call on. Left existing simple-text treatment for now, easy follow-up once you pick a direction.
- **Real brand SVG logos** in the logo strip — Pete is sourcing himself
- **PGP inline** in contact — blocked on hardware GPG setup
- **/work index page** — nav link uses the \`#work\` anchor on the homepage. If you want a dedicated /work/ index later, easy follow-up.

## Before merge

- Decide on the email alias: \`hello@petewatters.ie\` (used in the component) needs DNS forwarding to your real inbox. If you want a different alias, change in \`ContactSection.astro\`.
- Eyeball on the dev preview — sticky header behaviour, hamburger animation, contact section copy

## Test changes

- Removed assertion on \`.hero-name\` (no longer exists)
- New assertion: \`.header-availability\` contains "Available Sep 2026"
- New assertion: header has exactly 3 nav links (Work / Blog / CV)
- New assertion: contact section renders with email + social links
- New negative assertion: header has no social icons
- New assertion: case-studies section has \`id="work"\` for the nav anchor

## Linked issue

Closes #80