### PR TITLE
feat(hero): simplify to 'Engineer' + plan·build·ship with monoline glyphs

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -10,26 +10,32 @@ import ContactSection from '../components/ContactSection.astro';
       <h2 class="hero-headline" data-reveal>Engineer</h2>
       <p class="hero-rhythm" aria-label="plan, build, ship">
         <span class="rhythm-item">
-          <svg class="rhythm-glyph" viewBox="0 0 22 12" width="22" height="12" aria-hidden="true" focusable="false">
-            <circle cx="3" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <circle cx="19" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <path d="M5 6 Q11 1 17 6" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="2 1.5" />
+          <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="m12.99 6.74 1.93 3.44" />
+            <path d="M19.136 12a10 10 0 0 1-14.271 0" />
+            <path d="m21 21-2.16-3.84" />
+            <path d="m3 21 8.02-14.26" />
+            <circle cx="12" cy="5" r="2" />
           </svg>
           <span>plan</span>
         </span>
         <span class="rhythm-sep" aria-hidden="true">·</span>
         <span class="rhythm-item">
-          <svg class="rhythm-glyph" viewBox="0 0 18 12" width="18" height="12" aria-hidden="true" focusable="false">
-            <rect x="1" y="6.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <rect x="11" y="6.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
-            <rect x="6" y="1.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
+          <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="m15 12-9.373 9.373a1 1 0 0 1-3.001-3L12 9" />
+            <path d="m18 15 4-4" />
+            <path d="m21.5 11.5-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5" />
           </svg>
           <span>build</span>
         </span>
         <span class="rhythm-sep" aria-hidden="true">·</span>
         <span class="rhythm-item">
-          <svg class="rhythm-glyph" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true" focusable="false">
-            <path d="M3 11 L11 3 M6 3 L11 3 L11 8" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+          <svg class="rhythm-glyph" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+            <path d="M12 10.189V14" />
+            <path d="M12 2v3" />
+            <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6" />
+            <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-8.188-3.639a2 2 0 0 0-1.624 0L3 14a11.6 11.6 0 0 0 2.81 7.76" />
+            <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1s1.2 1 2.5 1c2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
           </svg>
           <span>ship</span>
         </span>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -7,14 +7,33 @@ import ContactSection from '../components/ContactSection.astro';
   <article class="homepage">
 
     <section class="hero">
-      <p class="hero-words" aria-label="Builder, Engineer, Shipper">
-        <span class="hero-word hero-word--accent">Builder</span>
-        <span class="hero-word-sep" aria-hidden="true">·</span>
-        <span class="hero-word">Engineer</span>
-        <span class="hero-word-sep" aria-hidden="true">·</span>
-        <span class="hero-word hero-word--accent">Shipper</span>
+      <h2 class="hero-headline" data-reveal>Engineer</h2>
+      <p class="hero-rhythm" aria-label="plan, build, ship">
+        <span class="rhythm-item">
+          <svg class="rhythm-glyph" viewBox="0 0 22 12" width="22" height="12" aria-hidden="true" focusable="false">
+            <circle cx="3" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.2" />
+            <circle cx="19" cy="6" r="2" fill="none" stroke="currentColor" stroke-width="1.2" />
+            <path d="M5 6 Q11 1 17 6" fill="none" stroke="currentColor" stroke-width="1.2" stroke-dasharray="2 1.5" />
+          </svg>
+          <span>plan</span>
+        </span>
+        <span class="rhythm-sep" aria-hidden="true">·</span>
+        <span class="rhythm-item">
+          <svg class="rhythm-glyph" viewBox="0 0 18 12" width="18" height="12" aria-hidden="true" focusable="false">
+            <rect x="1" y="6.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
+            <rect x="11" y="6.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
+            <rect x="6" y="1.5" width="6" height="4" fill="none" stroke="currentColor" stroke-width="1.2" />
+          </svg>
+          <span>build</span>
+        </span>
+        <span class="rhythm-sep" aria-hidden="true">·</span>
+        <span class="rhythm-item">
+          <svg class="rhythm-glyph" viewBox="0 0 14 14" width="14" height="14" aria-hidden="true" focusable="false">
+            <path d="M3 11 L11 3 M6 3 L11 3 L11 8" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" />
+          </svg>
+          <span>ship</span>
+        </span>
       </p>
-      <p class="hero-subtagline" data-reveal>PLAN IT · BUILD IT · SHIP IT</p>
       <p class="hero-bio" data-reveal>
         Ten years shipping crypto products people actually use — wallets, trading terminals,
         institutional interfaces — across Bitcoin, Stacks, Solana and EVM chains. I take a brief
@@ -333,81 +352,56 @@ import ContactSection from '../components/ContactSection.astro';
   /* HERO */
   .hero { padding: 3rem 0 2rem; }
 
-  .availability-badge {
-    display: inline-flex;
-    align-items: center;
-    gap: 0.5rem;
+  .hero-headline {
     font-family: var(--font-mono);
-    font-size: 12px;
-    letter-spacing: 0.05em;
-    color: var(--color-muted);
-    background: rgba(247, 147, 26, 0.06);
-    border: 1px solid rgba(247, 147, 26, 0.25);
-    padding: 0.35rem 0.75rem;
-    border-radius: 999px;
-    margin-bottom: 2rem;
-  }
-
-  .badge-dot {
-    width: 7px;
-    height: 7px;
-    border-radius: 50%;
-    background: var(--color-accent);
-    animation: badge-pulse 2.5s ease-in-out infinite;
-  }
-  @keyframes badge-pulse {
-    0%, 100% { opacity: 1; box-shadow: 0 0 0 0 rgba(247, 147, 26, 0.4); }
-    50%      { opacity: 0.6; box-shadow: 0 0 0 6px rgba(247, 147, 26, 0); }
-  }
-
-  .hero-name {
-    font-family: 'Monoton', cursive;
-    font-weight: 400;
-    font-size: clamp(2.2rem, 7vw, 4.5rem);
+    font-size: clamp(2.6rem, 7vw, 4.5rem);
+    font-weight: 600;
     line-height: 1.05;
-    margin: 0 0 1.5rem;
+    letter-spacing: -0.01em;
+    margin: 0 0 1.25rem;
     color: var(--color-text);
   }
 
-  .hero-words {
-    font-family: var(--font-mono);
-    font-size: clamp(1.4rem, 3.5vw, 2.2rem);
-    font-weight: 500;
-    margin: 0 0 1rem;
+  .hero-rhythm {
+    margin: 0 0 2.5rem;
     display: flex;
     flex-wrap: wrap;
-    gap: 0.6rem;
-    align-items: baseline;
+    gap: 0.6rem 0.9rem;
+    align-items: center;
+    font-family: var(--font-mono);
+    font-size: clamp(0.95rem, 1.8vw, 1.1rem);
+    color: var(--color-muted);
   }
 
-  .hero-word,
-  .hero-word-sep {
+  .rhythm-item {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
     opacity: 0;
-    transform: translateY(10px);
-    animation: hero-word-up 0.6s var(--ease-out-soft) forwards;
-    display: inline-block;
-    color: var(--color-text);
+    transform: translateY(8px);
+    animation: rhythm-fade-up 0.5s var(--ease-out-soft) forwards;
   }
-  .hero-word--accent { color: var(--color-accent); }
-  .hero-word-sep    { color: var(--color-faint); }
 
-  .hero-words > *:nth-child(1) { animation-delay: 0.35s; }
-  .hero-words > *:nth-child(2) { animation-delay: 0.45s; }
-  .hero-words > *:nth-child(3) { animation-delay: 0.55s; }
-  .hero-words > *:nth-child(4) { animation-delay: 0.65s; }
-  .hero-words > *:nth-child(5) { animation-delay: 0.75s; }
+  .rhythm-glyph {
+    color: var(--color-accent);
+    flex-shrink: 0;
+  }
 
-  @keyframes hero-word-up {
+  .rhythm-sep {
+    color: var(--color-faint);
+    opacity: 0.7;
+  }
+
+  .hero-rhythm > .rhythm-item:nth-of-type(1) { animation-delay: 0.35s; }
+  .hero-rhythm > .rhythm-item:nth-of-type(2) { animation-delay: 0.50s; }
+  .hero-rhythm > .rhythm-item:nth-of-type(3) { animation-delay: 0.65s; }
+
+  @keyframes rhythm-fade-up {
     to { opacity: 1; transform: translateY(0); }
   }
 
-  .hero-subtagline {
-    font-family: var(--font-mono);
-    font-size: 11px;
-    letter-spacing: 0.3em;
-    color: var(--color-faint);
-    text-transform: uppercase;
-    margin: 0 0 2.5rem;
+  @media (prefers-reduced-motion: reduce) {
+    .rhythm-item { animation: none; opacity: 1; transform: none; }
   }
 
   .hero-bio {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -29,15 +29,21 @@ test.describe('Home page', () => {
     await expect(page.locator('header.site-header h1 a')).toHaveText('Pete Watters');
   });
 
-  test('hero shows the three words, sub-tagline and bio', async ({ page }) => {
+  test('hero shows Engineer headline + plan/build/ship rhythm + bio', async ({ page }) => {
     await page.goto('/');
-    const words = page.locator('.hero-word');
-    await expect(words).toHaveCount(3);
-    await expect(words.nth(0)).toHaveText('Builder');
-    await expect(words.nth(1)).toHaveText('Engineer');
-    await expect(words.nth(2)).toHaveText('Shipper');
-    await expect(page.locator('.hero-subtagline')).toContainText('PLAN IT');
+    await expect(page.locator('.hero-headline')).toHaveText('Engineer');
+    const items = page.locator('.rhythm-item');
+    await expect(items).toHaveCount(3);
+    await expect(items.nth(0)).toContainText('plan');
+    await expect(items.nth(1)).toContainText('build');
+    await expect(items.nth(2)).toContainText('ship');
     await expect(page.locator('.hero-bio')).toContainText('crypto products');
+  });
+
+  test('rhythm items each have an inline monoline glyph SVG', async ({ page }) => {
+    await page.goto('/');
+    const glyphs = page.locator('.rhythm-item .rhythm-glyph');
+    await expect(glyphs).toHaveCount(3);
   });
 
   test('logo strip lists all six companies', async ({ page }) => {


### PR DESCRIPTION
## Summary

Replaces the three-word treatment (Builder · Engineer · Shipper) with a single \"Engineer\" headline and the verb rhythm \"plan · build · ship\" underneath. Each verb gets a small inline monoline SVG glyph in the accent colour, inspired by Ben Brouckaert's hero treatment at benbrk.com.

### Why

\"Engineer\" alone communicates the role without slotting Pete into a sub-discipline (frontend / full-stack / product) — your call from chat: *\"saying Engineer says what I am without labels to put me in a box.\"* The verb rhythm gives the cadence; the glyphs add visual punch without ceremony.

### Glyphs

- **plan** — two circles connected by a dashed curve (route/planning)
- **build** — three stacked rectangles (bricks/blocks)
- **ship** — outlined upward-right arrow (launch)

All inline SVG, `currentColor`-coloured (picks up the accent), scales with the surrounding text size.

### Cleanup

Removed dead CSS: \`.hero-words\`, \`.hero-word\`, \`.hero-word-sep\`, \`.hero-subtagline\`, and the orphaned \`.availability-badge\` styles left over from when the badge moved to the header in #81.

### Test changes

- Updated home.spec.ts to assert the new structure (`.hero-headline` = \"Engineer\", 3 `.rhythm-item` entries, each with a `.rhythm-glyph` SVG)
- Removed the now-stale `.hero-word` × 3 assertions

## Linked issue

Type: chore / cleanup (no linked issue) — follow-up to #81 (hero/header redesign).