### PR TITLE
ci: cache Playwright browsers + concurrency cancel-in-progress + drop [skip ci]

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ on:
     branches: [main, dev]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   playwright:
     runs-on: ubuntu-latest
@@ -20,7 +24,16 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-all-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright system deps (always)
+        run: npx playwright install-deps
+      - name: Install Playwright browser binaries (skip if cached)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install
       - run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -33,7 +33,16 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install chromium --with-deps
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright system deps (always)
+        run: npx playwright install-deps chromium
+      - name: Install Playwright Chromium binary (skip if cached)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
       - run: npm run build
       - run: npx bddgen --config playwright.bdd.config.ts
       - name: Regenerate snapshots
@@ -48,6 +57,11 @@ jobs:
           if git diff --staged --quiet; then
             echo "No baseline changes."
           else
-            git commit -m "chore(e2e): refresh visual-regression baselines [skip ci]"
-            git push
+            # No [skip ci]: let the regular Visual Regression workflow assert
+            # against the new baselines on this same commit. If it passes, the
+            # bootstrap actually worked; no need for a manual empty commit to
+            # validate.
+            git commit -m "chore(e2e): refresh visual-regression baselines"
+            # Explicit ref to avoid detached-HEAD / upstream-tracking ambiguity.
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# private working notes — never push
+.private/


### PR DESCRIPTION
## Summary

Three optimisations to make Actions runs faster and less prone to stale-CI-blocking issues, plus a small gitignore alignment.

### 1. Playwright browser binary cache
- New \`actions/cache@v4\` step in \`update-visual-baselines.yml\` and \`integration-tests.yml\`, keyed on \`package-lock.json\` hash
- Split the combined \`playwright install --with-deps\` into:
  - \`playwright install-deps\` (system apt packages, always runs)
  - \`playwright install <browser>\` (binary download, skipped on cache hit)
- Saves ~30-60s per run on workflows that touch Playwright
- **Note**: \`visual-regression.yml\` on PR #75 needs the same treatment — adding it to the follow-up after #75 merges (otherwise this PR would conflict with PR #75 over that file)

### 2. Concurrency cancel-in-progress
Added to \`deploy.yml\`, \`code-checks.yml\`, and \`integration-tests.yml\`. New commits on a PR kill stale builds instead of queuing them up — meaningful saving when you rebase or push fixes in quick succession. \`visual-regression.yml\` already has it from PR #75.

### 3. Drop \`[skip ci]\` from update-visual-baselines commit
The \`[skip ci]\` was originally defensive against infinite re-trigger, but the bootstrap workflow is \`workflow_dispatch\`-only — push commits *can't* re-trigger it. Letting the regular Visual Regression workflow run on the baseline-commit means we validate the new baselines in-band instead of needing a manual empty follow-up commit (which was the friction Pete hit on PR #75 today).

Also fixes the CodeRabbit-flagged \`git push\` ambiguity on the same workflow — now uses explicit \`git push origin "HEAD:\${GITHUB_REF_NAME}"\` per the recommendation. That fix never reached main from PR #78 because the fix commit landed on a closed branch.

### 4. Gitignore alignment
PR #74 added \`.private/\` to dev's \`.gitignore\` for never-push working notes. Main missed it (main hasn't received dev → main release since the split). Adding it on this PR so branches off main don't accidentally commit \`.private/\` contents.

## Expected impact

- **Integration tests workflow**: ~30-60s faster on cache hits (Playwright install was the dominant cost)
- **Deploy workflow on rapid PR pushes**: stale runs cancelled instead of queued — was burning ~3 min per cancelled build
- **Future baseline updates**: no manual empty commit needed to validate

## Linked issue

Type: chore / cleanup (no linked issue)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added concurrency management across all CI/CD workflows to automatically cancel in-progress runs when new builds are triggered, improving pipeline efficiency.
  * Optimized test execution with browser caching in integration and visual baseline regression tests, reducing test environment setup time.
  * Updated gitignore patterns.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/pete-watters/portfolio-pwa/pull/83?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->