### PR TITLE
docs: trim README + add RSS feed

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,6 +184,27 @@ npm run test:e2e:headless   # Playwright chromium
 
 ---
 
+## Project structure
+
+```
+src/
+  components/    # Astro components (BaseHead, Header, Nav, …)
+  content/
+    blog/        # Blog posts (markdown)
+    work/        # Case studies (markdown)
+    cv/          # CV content collection
+  layouts/       # BaseLayout, CvLayout
+  pages/         # Routes — /, /blog, /work/<slug>, /cv, rss.xml
+  styles/        # global.css
+public/
+  docs/          # PDFs (thesis, certifications)
+  img/ videos/   # Static media
+e2e/             # Playwright-BDD visual regression
+tests/           # Vitest unit tests
+```
+
+---
+
 ## Verified commits
 
 The `main` branch ruleset requires signed commits. GitHub squash-merges

--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -51,6 +51,6 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 ## Links
 
 - [petewatters.ie](https://petewatters.ie) — Portfolio & blog
-- [petewatters.ie/cv/full-stack](https://petewatters.ie/cv/full-stack) — CV
+- [petewatters.ie/cv](https://petewatters.ie/cv) — CV
 - [LinkedIn](https://www.linkedin.com/in/pete-watters/)
 - [StackOverflow](https://stackoverflow.com/users/1365580/peadar)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # petewatters.ie
 
+![Pete Watters — Senior Web3 Frontend Engineer](public/img/og.png)
+
 Personal portfolio and blog built with Astro, hosted on Cloudflare Pages.
 
 **Live:** [petewatters.ie](https://petewatters.ie)
@@ -12,39 +14,10 @@ Personal portfolio and blog built with Astro, hosted on Cloudflare Pages.
 - Playwright — E2E tests
 - Vite PWA — offline support and service worker
 
-## Development
+## Contributing & local development
 
-```bash
-npm install
-npm run dev          # Start dev server
-npm run build        # Production build
-npm run preview      # Preview production build
-```
-
-## Testing
-
-```bash
-npm run test:e2e:headless   # Playwright (chromium)
-npm run test:e2e:ui         # Playwright with UI
-npm run test:unit           # Vitest
-npm run lint                # ESLint
-```
-
-## Structure
-
-```
-src/
-  content/
-    blog/        # Blog posts (markdown)
-    cv/          # CV content collection
-  layouts/       # Astro layouts (BaseLayout, CvLayout)
-  pages/         # Routes (/, /blog, /cv)
-  components/    # Astro components
-public/
-  docs/          # PDFs (thesis, certifications)
-tests/
-  e2e/           # Playwright tests
-```
+Setup commands, testing, project structure, branching model, and PR
+conventions live in [CONTRIBUTING.md](./CONTRIBUTING.md).
 
 ## License
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "2.0.0",
       "dependencies": {
         "@astrojs/check": "^0.9.0",
+        "@astrojs/rss": "^4.0.18",
         "@astrojs/sitemap": "^3.7.2",
         "astro": "^5.0.0",
         "typescript": "^5.7.0"
@@ -302,6 +303,26 @@
       },
       "engines": {
         "node": "18.20.8 || ^20.3.0 || >=22.0.0"
+      }
+    },
+    "node_modules/@astrojs/rss": {
+      "version": "4.0.18",
+      "resolved": "https://registry.npmjs.org/@astrojs/rss/-/rss-4.0.18.tgz",
+      "integrity": "sha512-wc5DwKlbTEdgVAWnHy8krFTeQ42t1v/DJqeq5HtulYK3FYHE4krtRGjoyhS3eXXgfdV6Raoz2RU3wrMTFAitRg==",
+      "license": "MIT",
+      "dependencies": {
+        "fast-xml-parser": "^5.5.7",
+        "piccolore": "^0.1.3",
+        "zod": "^4.3.6"
+      }
+    },
+    "node_modules/@astrojs/rss/node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/@astrojs/sitemap": {
@@ -3524,6 +3545,18 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@nodable/entities": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@nodable/entities/-/entities-2.1.0.tgz",
+      "integrity": "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodable"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -8506,6 +8539,44 @@
       ],
       "license": "BSD-3-Clause"
     },
+    "node_modules/fast-xml-builder": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
+      "integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "path-expression-matcher": "^1.5.0",
+        "xml-naming": "^0.1.0"
+      }
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.8.0.tgz",
+      "integrity": "sha512-6bIM7fsJxeo3uXv7OncQYsBAMPJ7V16Slahl/6M98C/i2q+vB1+4a0MtrvYwDFEUrwDSbAmeLDRXsOBwrL7yAg==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@nodable/entities": "^2.1.0",
+        "fast-xml-builder": "^1.2.0",
+        "path-expression-matcher": "^1.5.0",
+        "strnum": "^2.3.0",
+        "xml-naming": "^0.1.0"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
     "node_modules/fastq": {
       "version": "1.20.1",
       "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
@@ -11153,6 +11224,21 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/path-expression-matcher": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/path-expression-matcher/-/path-expression-matcher-1.5.0.tgz",
+      "integrity": "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -12502,6 +12588,18 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/strnum": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-2.3.0.tgz",
+      "integrity": "sha512-ums3KNd42PGyx5xaoVTO1mjU1bH3NpY4vsrVlnv9PNGqQj8wd7rJ6nEypLrJ7z5vxK5RP0yMLo6J/Gsm62DI5Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/supports-preserve-symlinks-flag": {
       "version": "1.0.0",
@@ -15007,6 +15105,21 @@
       "integrity": "sha512-6BMfd8tYEnN4baG4emG9U0hdXM4gGuDU3ectXuVHnj71vwxTFI7WOpQJC4siTOlVtGqCUtj0ZQNsrvi6kZZTAQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/xml-naming": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
+      "integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=16.0.0"
+      }
     },
     "node_modules/xmlbuilder": {
       "version": "15.1.1",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.0",
+    "@astrojs/rss": "^4.0.18",
     "@astrojs/sitemap": "^3.7.2",
     "astro": "^5.0.0",
     "typescript": "^5.7.0"

--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -46,6 +46,7 @@ const jsonLd =
 <title>{pageTitle}</title>
 <meta name="description" content={pageDescription} />
 <link rel="canonical" href={canonicalURL} />
+<link rel="alternate" type="application/rss+xml" title={SITE_TITLE} href="/rss.xml" />
 <meta name="theme-color" content="#2b2b2b" />
 
 <link rel="shortcut icon" href="/img/favicon.ico" />

--- a/src/pages/rss.xml.ts
+++ b/src/pages/rss.xml.ts
@@ -1,0 +1,26 @@
+import rss from '@astrojs/rss';
+import { getCollection } from 'astro:content';
+import type { CollectionEntry } from 'astro:content';
+import type { APIContext } from 'astro';
+import { SITE_TITLE, SITE_DESCRIPTION } from '../consts';
+
+export async function GET(context: APIContext) {
+  const posts = (
+    await getCollection('blog', ({ data }: CollectionEntry<'blog'>) => !data.draft)
+  ).sort(
+    (a: CollectionEntry<'blog'>, b: CollectionEntry<'blog'>) =>
+      b.data.pubDate.valueOf() - a.data.pubDate.valueOf(),
+  );
+
+  return rss({
+    title: SITE_TITLE,
+    description: SITE_DESCRIPTION,
+    site: context.site ?? 'https://petewatters.ie',
+    items: posts.map((post: CollectionEntry<'blog'>) => ({
+      title: post.data.title,
+      description: post.data.description,
+      pubDate: post.data.pubDate,
+      link: `/blog/${post.id.replace(/\.md$/, '')}/`,
+    })),
+  });
+}


### PR DESCRIPTION
## Summary
- **README** trimmed to intro + OG banner + stack + license. Dev setup, testing, and project structure moved into `CONTRIBUTING.md` (which already had the dev commands — avoids a duplicate `LOCAL_DEV.md`).
- **CONTRIBUTING** gains a "Project structure" section reflecting the current layout.
- **RSS feed**: `@astrojs/rss` + `/rss.xml` (33 posts, newest-first) + a `<link rel="alternate">` in the head. This is the enabler for GitHub-profile-README blog auto-sync.
- Fixed a stale CV link in `GITHUB_PROFILE_README.md` (`/cv/full-stack` → `/cv`).

## Follow-up (separate, not in this PR)
- The auto-sync action itself lives in the `pete-watters/pete-watters` profile repo: a scheduled `gautamkrishnar/blog-post-workflow` reading `petewatters.ie/rss.xml` between `<!-- BLOG-POST-LIST -->` markers. No secrets needed.
- LinkedIn has no public profile-update API; deprioritised.