### PR TITLE
feat(nav): rename Blog to Writing

### DIFF
--- a/src/components/Nav.astro
+++ b/src/components/Nav.astro
@@ -1,7 +1,7 @@
 ---
 const links = [
   { href: '/#work', label: 'Work' },
-  { href: '/blog', label: 'Blog' },
+  { href: '/blog', label: 'Writing' },
   { href: '/cv/', label: 'CV' },
 ];
 ---

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -23,7 +23,7 @@ const { Content } = await render(post);
   publishedDate={post.data.pubDate}
 >
   <nav class="breadcrumbs" aria-label="Breadcrumb">
-    <a href="/">Home</a> <span class="breadcrumb-sep">&rsaquo;</span> <a href="/blog">Blog</a> <span class="breadcrumb-sep">&rsaquo;</span> <span class="breadcrumb-current">{post.data.title}</span>
+    <a href="/">Home</a> <span class="breadcrumb-sep">&rsaquo;</span> <a href="/blog">Writing</a> <span class="breadcrumb-sep">&rsaquo;</span> <span class="breadcrumb-current">{post.data.title}</span>
   </nav>
   <article class="blog-post" data-pagefind-body>
     <h1 data-pagefind-meta="title">{post.data.title}</h1>


### PR DESCRIPTION
## Summary
- Nav label "Blog" → "Writing" and the blog-post breadcrumb to match. Route stays `/blog`. The blog index page title is already "Writing" (from #91), so this aligns the nav with it.