### PR TITLE
feat(homepage): real GitHub contribution activity section

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,10 +26,10 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       HELIUS_KEY: ${{ secrets.HELIUS_KEY }}
       NFT_MINT: ${{ secrets.NFT_MINT }}
-      # PAT (classic, read:user) for the Open Source contribution section.
-      # Stored as the GH_CONTRIB_TOKEN repo secret — `GITHUB_TOKEN` can't be a
-      # secret name (reserved by Actions), so it's mapped to the env var here.
-      GITHUB_TOKEN: ${{ secrets.GH_CONTRIB_TOKEN }}
+      # Reuses the existing GH_PAT secret for the Open Source contribution
+      # section. Mapped to GITHUB_TOKEN because that name is reserved by Actions
+      # and can't be used as a secret name directly. Needs read:user access.
+      GITHUB_TOKEN: ${{ secrets.GH_PAT }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,10 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       HELIUS_KEY: ${{ secrets.HELIUS_KEY }}
       NFT_MINT: ${{ secrets.NFT_MINT }}
+      # PAT (classic, read:user) for the Open Source contribution section.
+      # Stored as the GH_CONTRIB_TOKEN repo secret — `GITHUB_TOKEN` can't be a
+      # secret name (reserved by Actions), so it's mapped to the env var here.
+      GITHUB_TOKEN: ${{ secrets.GH_CONTRIB_TOKEN }}
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -19,8 +19,8 @@ stats.weeks.forEach((week, i) => {
 
 const fmt = (n: number) => n.toLocaleString('en-US');
 
-// Curated landmark contributions (verified real PRs). Edit this list freely.
-// `post` links a matching blog write-up when one exists.
+// Curated landmark contributions — all verified merged PRs, each with a
+// matching blog write-up. `meta` is kept short for the compact grid.
 const notable: {
   repo: string;
   num: number;
@@ -30,41 +30,59 @@ const notable: {
 }[] = [
   {
     repo: 'leather-io/mono',
+    num: 161,
+    title: 'Monorepo & shared UI packages',
+    meta: 'Set up packages/ui · 31 files',
+    post: 'designing-a-monorepo',
+  },
+  {
+    repo: 'leather-io/mono',
     num: 1837,
-    title: 'Cross-platform Activity — one shared feature package across mobile + extension',
-    meta: '+4,796 / 152 files',
+    title: 'Cross-platform feature packages',
+    meta: 'One package, two surfaces · 152 files',
+    post: 'cross-platform-monorepo',
+  },
+  {
+    repo: 'leather-io/extension',
+    num: 4655,
+    title: 'Full-page view & container system rebuild',
+    meta: 'Radix Dialog · 358 files',
+    post: 'extension-containers',
   },
   {
     repo: 'leather-io/mono',
     num: 885,
-    title: 'Branded Types for Bitcoin addresses — compile-time address safety',
-    meta: '+1,002 / 47 files',
+    title: 'Branded types for Bitcoin addresses',
+    meta: 'Compile-time address safety · 47 files',
     post: 'branded-types-crypto-wallet',
   },
   {
     repo: 'leather-io/extension',
+    num: 4243,
+    title: 'Secret-key redesign + BIP-39 validation',
+    meta: 'Word-by-word mnemonic input · 27 files',
+    post: 'mnemonic-validation',
+  },
+  {
+    repo: 'leather-io/extension',
+    num: 4113,
+    title: 'Spam & scam token filtering',
+    meta: 'Phishing names out of the asset list',
+    post: 'spam-token-filtering',
+  },
+  {
+    repo: 'leather-io/extension',
+    num: 4325,
+    title: 'Modal routing refactor',
+    meta: 'Overlay + nested route state · 30 files',
+    post: 'modal-routing-browser-extension',
+  },
+  {
+    repo: 'leather-io/extension',
     num: 6085,
-    title: 'UTXO consolidation — removed validation blocking self-sends',
-    meta: '+6 / −10 · the best code is the code you delete',
+    title: 'UTXO consolidation — the 6-line fix',
+    meta: '+6 / −10 · the best code you delete',
     post: 'utxo-consolidation-six-lines',
-  },
-  {
-    repo: 'leather-io/mono',
-    num: 2067,
-    title: 'Multimedia collectibles gallery brought to the browser extension',
-    meta: 'Stacks SIP-9 + Bitcoin Ordinals',
-  },
-  {
-    repo: 'leather-io/mono',
-    num: 1130,
-    title: 'App-wide loading & error states — no flash of "$0" balances',
-    meta: '121 files',
-  },
-  {
-    repo: 'leather-io/mono',
-    num: 915,
-    title: 'Sanctions screening on mobile — compliance for a self-custodial wallet',
-    meta: '+592 / 67 files',
   },
 ];
 ---
@@ -145,7 +163,7 @@ const notable: {
               </span>
             </a>
             {pr.post && (
-              <a class="oss-story" href={`/blog/${pr.post}/`}>Read the story →</a>
+              <a class="oss-story" href={`/blog/${pr.post}/`}>Write-up →</a>
             )}
           </li>
         ))}
@@ -309,15 +327,15 @@ const notable: {
     list-style: none;
     padding: 0;
     margin: 0;
-    display: flex;
-    flex-direction: column;
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 0.6rem;
   }
   .oss-notable-item {
     display: flex;
     flex-direction: column;
-    gap: 0.4rem;
-    padding: 0.75rem 1rem;
+    gap: 0.3rem;
+    padding: 0.7rem 0.9rem;
     border: 1px solid var(--color-border);
     border-radius: 0.5rem;
     transition: border-color 0.2s, background 0.2s;
@@ -334,8 +352,9 @@ const notable: {
   }
   .oss-pr-title {
     color: var(--color-text);
-    font-size: 0.95rem;
-    line-height: 1.4;
+    font-size: 0.9rem;
+    font-weight: 600;
+    line-height: 1.35;
   }
   .oss-pr-meta {
     font-family: var(--font-mono);
@@ -353,6 +372,7 @@ const notable: {
 
   @media (max-width: 600px) {
     .oss-overview { grid-template-columns: 1fr; }
+    .oss-notable { grid-template-columns: 1fr; }
     .oss-top { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
     .oss-bigstats > div { align-items: flex-start; }
   }

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -233,40 +233,47 @@ const notable: {
   }
 
   /* CALENDAR */
+  /* Calendar scales to fit the container — 53 equal columns, square cells.
+     No horizontal scroll at any width; cells shrink on narrow screens. */
   .oss-calendar {
     border: 1px solid var(--color-border);
     border-radius: 0.6rem;
     padding: 1rem;
-    overflow-x: auto;
+  }
+  .oss-months,
+  .oss-grid {
+    display: grid;
+    grid-template-columns: repeat(53, minmax(0, 1fr));
+    gap: 2px;
+    width: 100%;
+    max-width: 760px;
   }
   .oss-months {
-    display: grid;
-    grid-template-columns: repeat(53, 13px);
-    gap: 3px;
     font-family: var(--font-mono);
     font-size: 10px;
     color: var(--color-faint);
     margin-bottom: 4px;
-    min-width: max-content;
   }
   .oss-months span {
     grid-row: 1;
-  }
-  .oss-grid {
-    display: flex;
-    gap: 3px;
-    min-width: max-content;
+    white-space: nowrap;
   }
   .oss-week {
-    display: grid;
-    grid-template-rows: repeat(7, 10px);
-    gap: 3px;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
   }
   .oss-day {
-    width: 10px;
-    height: 10px;
     border-radius: 2px;
     background: #ebedf0;
+  }
+  .oss-grid .oss-day {
+    width: 100%;
+    aspect-ratio: 1;
+  }
+  .oss-legend .oss-day {
+    width: 10px;
+    height: 10px;
     display: inline-block;
   }
   .oss-day[data-level='1'] { background: #ffd9a0; }

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -20,7 +20,14 @@ stats.weeks.forEach((week, i) => {
 const fmt = (n: number) => n.toLocaleString('en-US');
 
 // Curated landmark contributions (verified real PRs). Edit this list freely.
-const notable = [
+// `post` links a matching blog write-up when one exists.
+const notable: {
+  repo: string;
+  num: number;
+  title: string;
+  meta: string;
+  post?: string;
+}[] = [
   {
     repo: 'leather-io/mono',
     num: 1837,
@@ -32,6 +39,20 @@ const notable = [
     num: 885,
     title: 'Branded Types for Bitcoin addresses — compile-time address safety',
     meta: '+1,002 / 47 files',
+    post: 'branded-types-crypto-wallet',
+  },
+  {
+    repo: 'leather-io/extension',
+    num: 6085,
+    title: 'UTXO consolidation — removed validation blocking self-sends',
+    meta: '+6 / −10 · the best code is the code you delete',
+    post: 'utxo-consolidation-six-lines',
+  },
+  {
+    repo: 'leather-io/mono',
+    num: 2067,
+    title: 'Multimedia collectibles gallery brought to the browser extension',
+    meta: 'Stacks SIP-9 + Bitcoin Ordinals',
   },
   {
     repo: 'leather-io/mono',
@@ -41,9 +62,9 @@ const notable = [
   },
   {
     repo: 'leather-io/mono',
-    num: 2067,
-    title: 'Multimedia collectibles gallery brought to the browser extension',
-    meta: 'Stacks SIP-9 + Bitcoin Ordinals',
+    num: 915,
+    title: 'Sanctions screening on mobile — compliance for a self-custodial wallet',
+    meta: '+592 / 67 files',
   },
 ];
 ---
@@ -116,13 +137,16 @@ const notable = [
       <p class="oss-notable-label">Landmark contributions</p>
       <ul class="oss-notable">
         {notable.map((pr) => (
-          <li>
-            <a href={`https://github.com/${pr.repo}/pull/${pr.num}`} target="_blank" rel="noopener noreferrer">
+          <li class="oss-notable-item">
+            <a class="oss-pr-link" href={`https://github.com/${pr.repo}/pull/${pr.num}`} target="_blank" rel="noopener noreferrer">
               <span class="oss-pr-title">{pr.title}</span>
               <span class="oss-pr-meta">
                 {pr.repo}#{pr.num} · {pr.meta}
               </span>
             </a>
+            {pr.post && (
+              <a class="oss-story" href={`/blog/${pr.post}/`}>Read the story →</a>
+            )}
           </li>
         ))}
       </ul>
@@ -289,19 +313,24 @@ const notable = [
     flex-direction: column;
     gap: 0.5rem;
   }
-  .oss-notable a {
+  .oss-notable-item {
     display: flex;
     flex-direction: column;
-    gap: 0.15rem;
+    gap: 0.4rem;
     padding: 0.75rem 1rem;
     border: 1px solid var(--color-border);
     border-radius: 0.5rem;
-    text-decoration: none;
     transition: border-color 0.2s, background 0.2s;
   }
-  .oss-notable a:hover {
+  .oss-notable-item:hover {
     border-color: var(--color-accent);
     background: rgba(247, 147, 26, 0.04);
+  }
+  .oss-pr-link {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    text-decoration: none;
   }
   .oss-pr-title {
     color: var(--color-text);
@@ -313,6 +342,14 @@ const notable = [
     font-size: 11px;
     color: var(--color-faint);
   }
+  .oss-story {
+    width: fit-content;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-accent);
+    text-decoration: none;
+  }
+  .oss-story:hover { text-decoration: underline; }
 
   @media (max-width: 600px) {
     .oss-overview { grid-template-columns: 1fr; }

--- a/src/components/OpenSource.astro
+++ b/src/components/OpenSource.astro
@@ -1,0 +1,322 @@
+---
+import { getGitHubStats } from '../lib/github';
+import { GITHUB, SOCIAL } from '../consts';
+
+const stats = await getGitHubStats(GITHUB.USERNAME);
+
+const MONTHS = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+const monthLabels: { label: string; col: number }[] = [];
+let lastMonth = -1;
+stats.weeks.forEach((week, i) => {
+  const first = week[0];
+  if (!first) return;
+  const m = new Date(first.date + 'T00:00:00Z').getUTCMonth();
+  if (m !== lastMonth) {
+    monthLabels.push({ label: MONTHS[m], col: i + 1 });
+    lastMonth = m;
+  }
+});
+
+const fmt = (n: number) => n.toLocaleString('en-US');
+
+// Curated landmark contributions (verified real PRs). Edit this list freely.
+const notable = [
+  {
+    repo: 'leather-io/mono',
+    num: 1837,
+    title: 'Cross-platform Activity — one shared feature package across mobile + extension',
+    meta: '+4,796 / 152 files',
+  },
+  {
+    repo: 'leather-io/mono',
+    num: 885,
+    title: 'Branded Types for Bitcoin addresses — compile-time address safety',
+    meta: '+1,002 / 47 files',
+  },
+  {
+    repo: 'leather-io/mono',
+    num: 1130,
+    title: 'App-wide loading & error states — no flash of "$0" balances',
+    meta: '121 files',
+  },
+  {
+    repo: 'leather-io/mono',
+    num: 2067,
+    title: 'Multimedia collectibles gallery brought to the browser extension',
+    meta: 'Stacks SIP-9 + Bitcoin Ordinals',
+  },
+];
+---
+
+{
+  stats.available && (
+    <section class="oss" id="open-source">
+      <div class="oss-head">
+        <p class="section-label">Open source</p>
+        <a class="oss-github" href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer">
+          @{GITHUB.USERNAME} on GitHub →
+        </a>
+      </div>
+
+      <div class="oss-top">
+        <h2 class="oss-title">Contribution activity</h2>
+        <div class="oss-bigstats">
+          <div>
+            <span class="oss-big">{fmt(stats.totalContributions)}</span>
+            <span class="oss-big-label">contributions this year</span>
+          </div>
+          <div>
+            <span class="oss-big">{stats.currentStreak}</span>
+            <span class="oss-big-label">day streak</span>
+          </div>
+        </div>
+      </div>
+
+      <div class="oss-calendar" role="img" aria-label={`${fmt(stats.totalContributions)} GitHub contributions in the last year`}>
+        <div class="oss-months">
+          {monthLabels.map((m) => (
+            <span style={`grid-column: ${m.col}`}>{m.label}</span>
+          ))}
+        </div>
+        <div class="oss-grid">
+          {stats.weeks.map((week) => (
+            <div class="oss-week">
+              {week.map((day) => (
+                <span class="oss-day" data-level={day.level} title={`${day.count} on ${day.date}`} />
+              ))}
+            </div>
+          ))}
+        </div>
+        <div class="oss-legend">
+          <span>Less</span>
+          <span class="oss-day" data-level="0" />
+          <span class="oss-day" data-level="1" />
+          <span class="oss-day" data-level="2" />
+          <span class="oss-day" data-level="3" />
+          <span class="oss-day" data-level="4" />
+          <span>More</span>
+        </div>
+      </div>
+
+      <dl class="oss-overview">
+        <div class="oss-stat">
+          <dt>Pull requests</dt>
+          <dd>{fmt(stats.pullRequests)}</dd>
+        </div>
+        <div class="oss-stat">
+          <dt>Code reviews</dt>
+          <dd>{fmt(stats.reviews)}</dd>
+        </div>
+        <div class="oss-stat">
+          <dt>Commits</dt>
+          <dd>{fmt(stats.commits)}</dd>
+        </div>
+      </dl>
+
+      <p class="oss-notable-label">Landmark contributions</p>
+      <ul class="oss-notable">
+        {notable.map((pr) => (
+          <li>
+            <a href={`https://github.com/${pr.repo}/pull/${pr.num}`} target="_blank" rel="noopener noreferrer">
+              <span class="oss-pr-title">{pr.title}</span>
+              <span class="oss-pr-meta">
+                {pr.repo}#{pr.num} · {pr.meta}
+              </span>
+            </a>
+          </li>
+        ))}
+      </ul>
+    </section>
+  )
+}
+
+<style>
+  .oss {
+    --color-accent: #f7931a;
+    margin: 4rem 0 0;
+  }
+
+  .oss-head {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem;
+    flex-wrap: wrap;
+  }
+  .oss-github {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--color-muted);
+    text-decoration: none;
+  }
+  .oss-github:hover { color: var(--color-accent); }
+
+  .oss-top {
+    display: flex;
+    align-items: flex-end;
+    justify-content: space-between;
+    gap: 1.5rem;
+    flex-wrap: wrap;
+    margin: 0.5rem 0 1.5rem;
+  }
+  .oss-title {
+    font-family: var(--font-sans);
+    font-size: clamp(1.5rem, 3vw, 2rem);
+    font-weight: 700;
+    margin: 0;
+  }
+  .oss-bigstats {
+    display: flex;
+    gap: 2rem;
+  }
+  .oss-bigstats > div {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    line-height: 1.1;
+  }
+  .oss-big {
+    font-family: var(--font-mono);
+    font-size: clamp(1.4rem, 3vw, 1.9rem);
+    font-weight: 700;
+    color: var(--color-text);
+  }
+  .oss-big-label {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-faint);
+    margin-top: 0.2rem;
+  }
+
+  /* CALENDAR */
+  .oss-calendar {
+    border: 1px solid var(--color-border);
+    border-radius: 0.6rem;
+    padding: 1rem;
+    overflow-x: auto;
+  }
+  .oss-months {
+    display: grid;
+    grid-template-columns: repeat(53, 13px);
+    gap: 3px;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-faint);
+    margin-bottom: 4px;
+    min-width: max-content;
+  }
+  .oss-months span {
+    grid-row: 1;
+  }
+  .oss-grid {
+    display: flex;
+    gap: 3px;
+    min-width: max-content;
+  }
+  .oss-week {
+    display: grid;
+    grid-template-rows: repeat(7, 10px);
+    gap: 3px;
+  }
+  .oss-day {
+    width: 10px;
+    height: 10px;
+    border-radius: 2px;
+    background: #ebedf0;
+    display: inline-block;
+  }
+  .oss-day[data-level='1'] { background: #ffd9a0; }
+  .oss-day[data-level='2'] { background: #ffb454; }
+  .oss-day[data-level='3'] { background: #f7931a; }
+  .oss-day[data-level='4'] { background: #b8690c; }
+
+  .oss-legend {
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+    gap: 4px;
+    margin-top: 0.6rem;
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--color-faint);
+  }
+
+  /* OVERVIEW */
+  .oss-overview {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1rem;
+    margin: 1.5rem 0 0;
+    padding: 0;
+  }
+  .oss-stat {
+    border: 1px solid var(--color-border);
+    border-radius: 0.6rem;
+    padding: 1rem 1.25rem;
+  }
+  .oss-stat dt {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    color: var(--color-faint);
+  }
+  .oss-stat dd {
+    font-family: var(--font-mono);
+    font-size: clamp(1.6rem, 4vw, 2.2rem);
+    font-weight: 700;
+    color: var(--color-text);
+    margin: 0.3rem 0 0;
+  }
+
+  /* NOTABLE */
+  .oss-notable-label {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: var(--color-faint);
+    margin: 2rem 0 0.75rem;
+  }
+  .oss-notable {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+  }
+  .oss-notable a {
+    display: flex;
+    flex-direction: column;
+    gap: 0.15rem;
+    padding: 0.75rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.5rem;
+    text-decoration: none;
+    transition: border-color 0.2s, background 0.2s;
+  }
+  .oss-notable a:hover {
+    border-color: var(--color-accent);
+    background: rgba(247, 147, 26, 0.04);
+  }
+  .oss-pr-title {
+    color: var(--color-text);
+    font-size: 0.95rem;
+    line-height: 1.4;
+  }
+  .oss-pr-meta {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--color-faint);
+  }
+
+  @media (max-width: 600px) {
+    .oss-overview { grid-template-columns: 1fr; }
+    .oss-top { flex-direction: column; align-items: flex-start; gap: 0.75rem; }
+    .oss-bigstats > div { align-items: flex-start; }
+  }
+</style>

--- a/src/lib/github.ts
+++ b/src/lib/github.ts
@@ -1,0 +1,121 @@
+// Build-time fetch of GitHub contribution data for the Open Source section.
+// Requires a GITHUB_TOKEN env var (any token with default read scopes is enough
+// to read a public user's contributions). Degrades gracefully to `available:
+// false` when the token is missing or the request fails — the section then
+// hides itself rather than rendering an empty shell.
+
+export interface ContribDay {
+  date: string;
+  count: number;
+  level: number; // 0–4
+}
+
+export interface GitHubStats {
+  available: boolean;
+  totalContributions: number;
+  pullRequests: number;
+  reviews: number;
+  commits: number;
+  currentStreak: number;
+  weeks: ContribDay[][];
+}
+
+const LEVELS: Record<string, number> = {
+  NONE: 0,
+  FIRST_QUARTILE: 1,
+  SECOND_QUARTILE: 2,
+  THIRD_QUARTILE: 3,
+  FOURTH_QUARTILE: 4,
+};
+
+const QUERY = `
+  query($login: String!) {
+    user(login: $login) {
+      contributionsCollection {
+        totalCommitContributions
+        totalPullRequestContributions
+        totalPullRequestReviewContributions
+        contributionCalendar {
+          totalContributions
+          weeks {
+            contributionDays { date contributionCount contributionLevel }
+          }
+        }
+      }
+    }
+  }
+`;
+
+const EMPTY: GitHubStats = {
+  available: false,
+  totalContributions: 0,
+  pullRequests: 0,
+  reviews: 0,
+  commits: 0,
+  currentStreak: 0,
+  weeks: [],
+};
+
+function currentStreak(weeks: ContribDay[][]): number {
+  const days = weeks.flat().sort((a, b) => a.date.localeCompare(b.date));
+  let i = days.length - 1;
+  // Skip trailing empty days (e.g. today before the first commit) so they
+  // don't read as a broken streak.
+  while (i >= 0 && days[i].count === 0) i--;
+  let streak = 0;
+  while (i >= 0 && days[i].count > 0) {
+    streak++;
+    i--;
+  }
+  return streak;
+}
+
+export async function getGitHubStats(login: string): Promise<GitHubStats> {
+  const token = import.meta.env.GITHUB_TOKEN;
+  if (!token) {
+    console.warn('[github] GITHUB_TOKEN not set — hiding Open Source section');
+    return EMPTY;
+  }
+
+  try {
+    const res = await fetch('https://api.github.com/graphql', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ query: QUERY, variables: { login } }),
+    });
+
+    if (!res.ok) {
+      console.warn(`[github] GraphQL ${res.status} ${res.statusText} — hiding section`);
+      return EMPTY;
+    }
+
+    const json = await res.json();
+    const c = json?.data?.user?.contributionsCollection;
+    if (!c) return EMPTY;
+
+    const weeks: ContribDay[][] = c.contributionCalendar.weeks.map(
+      (w: { contributionDays: { date: string; contributionCount: number; contributionLevel: string }[] }) =>
+        w.contributionDays.map((d) => ({
+          date: d.date,
+          count: d.contributionCount,
+          level: LEVELS[d.contributionLevel] ?? 0,
+        })),
+    );
+
+    return {
+      available: true,
+      totalContributions: c.contributionCalendar.totalContributions,
+      pullRequests: c.totalPullRequestContributions,
+      reviews: c.totalPullRequestReviewContributions,
+      commits: c.totalCommitContributions,
+      currentStreak: currentStreak(weeks),
+      weeks,
+    };
+  } catch (err) {
+    console.warn('[github] contribution fetch failed — hiding section', err);
+    return EMPTY;
+  }
+}

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -1,5 +1,6 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
+import OpenSource from '../components/OpenSource.astro';
 import ContactSection from '../components/ContactSection.astro';
 ---
 
@@ -209,6 +210,8 @@ import ContactSection from '../components/ContactSection.astro';
         </div>
       </article>
     </section>
+
+    <OpenSource />
 
     <section class="timeline">
       <p class="section-label">Resume 2014 → 2026</p>


### PR DESCRIPTION
## Summary
- New **Open Source** section on the homepage (between case studies and the timeline): a live contribution **heatmap** (Bitcoin-orange), **stat cards** (Pull requests / Code reviews / Commits), a **streak**, and a curated list of **landmark leather-io PRs**.
- All data is **real**, fetched at build time from the GitHub GraphQL API (`contributionsCollection`). Last-year numbers: ~1,690 contributions, 437 PRs, 454 reviews, 647 commits.

## ⚠️ Required setup: a GitHub PAT (the build runs in GitHub Actions)
The build happens in the `Deploy` workflow (`npm run build`), not Cloudflare's builder — so the token is a **GitHub Actions secret**, same as `HELIUS_KEY`:
1. Create a **classic PAT** with the `read:user` scope (GitHub → Settings → Developer settings → Tokens (classic)).
2. Add it as a repo secret named **`GH_CONTRIB_TOKEN`** (can't use `GITHUB_TOKEN` — reserved by Actions).
3. This PR already maps it to the `GITHUB_TOKEN` build env var in `deploy.yml`.

Without the secret, the section **hides itself** (graceful fallback — verified the no-token build is clean).

## Notes
- Heatmap is Bitcoin-orange (on-brand). Swapping to GitHub-green is a 4-line CSS change.
- "Landmark contributions" is a curated list of verified real PRs — easy to edit in `OpenSource.astro`.
- Did **not** copy the "Top 1% Global Contributor" badge from the reference — no real metric behind it.