### PR TITLE
docs(profile): sync landmark contributions with the site

### DIFF
--- a/GITHUB_PROFILE_README.md
+++ b/GITHUB_PROFILE_README.md
@@ -15,23 +15,29 @@ Currently at [Trust Machines](https://trustmachines.co), building [Leather](http
 
 ## Notable open-source contributions
 
-**Monorepo architecture for Leather wallet** — Designed the mono-repo that consolidated the browser extension, mobile app and shared packages into a single repository with automated npm publishing.
-[leather-wallet/mono#8](https://github.com/leather-wallet/mono/pull/8)
+**Monorepo & shared UI packages** — Set up the shared `packages/ui` foundation so the browser extension and mobile app consume the same components.
+[leather-io/mono#161](https://github.com/leather-io/mono/pull/161)
 
-**Mnemonic validation on wallet sign-in** — Replaced a single textarea with word-by-word input and real-time BIP-39 validation using `@scure/bip39`. 739 additions across 27 files including new E2E tests.
-[leather-wallet/extension#4243](https://github.com/leather-wallet/extension/pull/4243)
+**Cross-platform feature packages** — Refactored Activity into a shared feature package serving both mobile and the extension. 152 files.
+[leather-io/mono#1837](https://github.com/leather-io/mono/pull/1837)
 
-**Full-page container system rebuild** — Replaced the entire drawer and container system with Radix Dialog, unified headers and standardised viewport widths. ~100 files, 8 bugs fixed.
-[leather-wallet/extension#4655](https://github.com/leather-wallet/extension/pull/4655)
+**Full-page view & container system rebuild** — Replaced the drawer/container system with Radix Dialog, unified headers and standardised viewport widths. 358 files.
+[leather-io/extension#4655](https://github.com/leather-io/extension/pull/4655)
 
-**Modal routing refactor** — Fixed overlay modal routing to properly handle background content, direct navigation and nested route state in the browser extension.
-[leather-wallet/extension#4325](https://github.com/leather-wallet/extension/pull/4325)
+**Branded types for Bitcoin addresses** — Compile-time safety so a BTC address can't be passed where a Stacks one is expected. 47 files.
+[leather-io/mono#885](https://github.com/leather-io/mono/pull/885)
 
-**Spam token filtering** — Added detection and filtering of scam token names containing URLs and phishing text in the wallet's asset list.
-[leather-wallet/extension#4113](https://github.com/leather-wallet/extension/pull/4113)
+**Secret-key redesign + BIP-39 validation** — Word-by-word mnemonic input with real-time `@scure/bip39` validation on wallet sign-in. 27 files.
+[leather-io/extension#4243](https://github.com/leather-io/extension/pull/4243)
 
-**Collectibles refactor across monorepo** — Introduced shared `CollectibleView` type, moved UI components into their respective apps, added token detail screens and Send Inscription flow. 5,783 additions.
-[leather-io/mono#1903](https://github.com/leather-io/mono/pull/1903)
+**Spam & scam token filtering** — Detect and filter phishing/scam token names (URLs, spam words) out of the asset list.
+[leather-io/extension#4113](https://github.com/leather-io/extension/pull/4113)
+
+**Modal routing refactor** — Fixed overlay modal routing for background content, direct navigation and nested route state in the extension. 30 files.
+[leather-io/extension#4325](https://github.com/leather-io/extension/pull/4325)
+
+**UTXO consolidation — the 6-line fix** — Removed validation blocking self-sends so users could consolidate dust. +6/−10. The best code is the code you delete.
+[leather-io/extension#6085](https://github.com/leather-io/extension/pull/6085)
 
 ## Tech
 


### PR DESCRIPTION
## Summary
- Updates `GITHUB_PROFILE_README.md` so the contributions list matches the homepage Open Source section (PR #94): the same verified 8 PRs.
- Corrects bad refs: `mono#8` was a CI chore (real monorepo PR is `#161`); the collectibles `#1903` was closed (dropped). All links now point at the canonical `leather-io` org.

## Note
This is the in-repo source copy. Remember to paste the same list into your actual `pete-watters/pete-watters` profile repo README.