### PR TITLE
Persistent sidebar across all pages (blog, work, CV)

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -1,0 +1,274 @@
+---
+import { SOCIAL } from '../consts';
+
+interface Props {
+  isHome?: boolean;
+}
+const { isHome = false } = Astro.props;
+const Title = isHome ? 'h1' : 'p';
+---
+
+<aside class="app-sidebar">
+  <div class="rail-top">
+    <a class="rail-avatar-link" href="/" aria-label="Pete Watters — home">
+      <img
+        class="rail-avatar"
+        src="https://github.com/pete-watters.png"
+        alt="Pete Watters"
+        width="92"
+        height="92"
+        loading="eager"
+      />
+    </a>
+    <p class="rail-name">Pete Watters</p>
+    <Title class="rail-title"><span class="hl-accent">Web3</span> Engineer</Title>
+    <p class="hero-rhythm rail-rhythm" aria-label="plan, build, ship">
+      <span class="rhythm-item">
+        <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="m12.99 6.74 1.93 3.44" />
+          <path d="M19.136 12a10 10 0 0 1-14.271 0" />
+          <path d="m21 21-2.16-3.84" />
+          <path d="m3 21 8.02-14.26" />
+          <circle cx="12" cy="5" r="2" />
+        </svg>
+        <span>plan</span>
+      </span>
+      <span class="rhythm-sep" aria-hidden="true">·</span>
+      <span class="rhythm-item">
+        <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="m15 12-9.373 9.373a1 1 0 0 1-3.001-3L12 9" />
+          <path d="m18 15 4-4" />
+          <path d="m21.5 11.5-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5" />
+        </svg>
+        <span>build</span>
+      </span>
+      <span class="rhythm-sep" aria-hidden="true">·</span>
+      <span class="rhythm-item">
+        <svg class="rhythm-glyph" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
+          <path d="M12 10.189V14" />
+          <path d="M12 2v3" />
+          <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6" />
+          <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-8.188-3.639a2 2 0 0 0-1.624 0L3 14a11.6 11.6 0 0 0 2.81 7.76" />
+          <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1s1.2 1 2.5 1c2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
+        </svg>
+        <span>ship</span>
+      </span>
+    </p>
+    <p class="rail-bio">
+      Front end specialist with an eye for design. Passionate about UX and comfortable
+      delivering products across the stack. Building for the web for nearly 20 years —
+      the last decade in crypto.
+    </p>
+    <div class="rail-shipped">
+      <p class="rail-shipped-label">Shipped at</p>
+      <ul class="rail-shipped-list">
+        <li>Kraken</li>
+        <li>Fidelity</li>
+        <li>Bank of America</li>
+        <li>Xapo</li>
+        <li>Leather</li>
+        <li>Qredo</li>
+      </ul>
+    </div>
+  </div>
+
+  <nav class="rail-nav" aria-label="Primary">
+    <a href="/#work">Work</a>
+    <a href="/blog">Writing</a>
+    <a href="/cv">CV</a>
+  </nav>
+
+  <div class="rail-bottom">
+    <div class="rail-coins" aria-hidden="true">
+      <span class="coin"><img class="coin-face" src="/img/tokens/btc.svg" alt="" width="46" height="46" loading="lazy" /></span>
+      <span class="coin"><img class="coin-face" src="/img/tokens/eth.svg" alt="" width="46" height="46" loading="lazy" /></span>
+      <span class="coin"><img class="coin-face" src="/img/tokens/stx.svg" alt="" width="46" height="46" loading="lazy" /></span>
+      <span class="coin"><img class="coin-face" src="/img/tokens/sol.svg" alt="" width="46" height="46" loading="lazy" /></span>
+    </div>
+    <a class="rail-availability" href="/#contact">
+      <span class="rail-availability-dot" aria-hidden="true"></span>
+      Available for remote work 09/26
+    </a>
+    <div class="rail-social">
+      <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer"><img src="/img/social/github.svg" alt="" width="15" height="15" />GitHub</a>
+      <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer"><img src="/img/social/x.svg" alt="" width="15" height="15" />X</a>
+      <a href={SOCIAL.LINKEDIN} target="_blank" rel="noopener noreferrer"><img src="/img/social/linkedin.svg" alt="" width="15" height="15" />LinkedIn</a>
+    </div>
+  </div>
+</aside>
+
+<style>
+  .app-sidebar {
+    --color-accent: #f7931a;
+    --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
+    flex: 0 0 clamp(264px, 24vw, 340px);
+    align-self: flex-start;
+    position: sticky;
+    top: 0;
+    height: 100vh;
+    overflow-y: auto;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+    padding: 2.5rem 2rem;
+    color: #fff;
+    text-align: left;
+    background:
+      radial-gradient(620px 340px at 25% 0%, rgba(247, 147, 26, 0.16), transparent 62%),
+      linear-gradient(170deg, #161616 0%, #1d1d1d 100%);
+  }
+  .rail-top { display: flex; flex-direction: column; }
+  .rail-avatar-link { display: inline-block; width: max-content; }
+  .rail-avatar {
+    width: 92px;
+    height: 92px;
+    border-radius: 50%;
+    border: 2px solid rgba(255, 255, 255, 0.14);
+    object-fit: cover;
+    display: block;
+    margin: 0 0 1.25rem;
+  }
+  .rail-name {
+    font-family: 'Space Grotesk', var(--font-sans);
+    font-size: 0.95rem;
+    font-weight: 500;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: #9a9a9a;
+    margin: 0 0 0.35rem;
+  }
+  .rail-title {
+    font-family: 'Space Grotesk', var(--font-sans);
+    font-size: clamp(1.6rem, 2.4vw, 2.1rem);
+    font-weight: 700;
+    line-height: 1.08;
+    letter-spacing: -0.02em;
+    margin: 0 0 1.1rem;
+    color: #fff;
+  }
+  .hl-accent { color: var(--color-accent); }
+
+  .hero-rhythm {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.6rem 0.9rem;
+    align-items: center;
+    font-family: var(--font-mono);
+  }
+  .rail-rhythm { margin: 0 0 1.1rem; font-size: 0.82rem; color: #ededed; }
+  .rail-rhythm .rhythm-item > span { color: #ededed; }
+  .rail-rhythm .rhythm-sep { color: #8a8a8a; }
+  .rhythm-item { display: inline-flex; align-items: center; gap: 0.4rem; }
+  .rhythm-glyph { color: var(--color-accent); flex-shrink: 0; }
+
+  .rail-bio { margin: 0; font-size: 0.92rem; line-height: 1.6; color: #cfcfcf; }
+
+  .rail-shipped { margin-top: 1.5rem; }
+  .rail-shipped-label {
+    font-family: var(--font-mono);
+    font-size: 0.66rem;
+    letter-spacing: 0.14em;
+    text-transform: uppercase;
+    color: #8a8a8a;
+    margin: 0 0 0.55rem;
+  }
+  .rail-shipped-list {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.3rem 0.85rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+    color: #bdbdbd;
+  }
+  .rail-shipped-list li { white-space: nowrap; }
+
+  .rail-nav {
+    display: flex;
+    flex-direction: column;
+    gap: 0.35rem;
+    font-family: 'Space Grotesk', var(--font-sans);
+  }
+  .rail-nav a {
+    color: #e6e6e6;
+    text-decoration: none;
+    font-size: 1.05rem;
+    font-weight: 500;
+    padding: 0.15rem 0;
+    width: max-content;
+    border-bottom: 1px solid transparent;
+    transition: color 0.2s ease, border-color 0.2s ease;
+  }
+  .rail-nav a:hover { color: var(--color-accent); border-color: var(--color-accent); }
+
+  .rail-bottom { display: flex; flex-direction: column; gap: 1.5rem; margin-top: auto; }
+  .rail-coins { display: flex; gap: 0.7rem; }
+  .coin { display: block; }
+  .coin-face {
+    display: block;
+    width: 46px;
+    height: 46px;
+    border-radius: 50%;
+    box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+  }
+  .rail-availability {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    width: max-content;
+    font-family: var(--font-mono);
+    font-size: 0.78rem;
+    letter-spacing: 0.02em;
+    color: #d6d6d6;
+    text-decoration: none;
+    padding: 0.3rem 0.7rem;
+    border: 1px solid rgba(255, 255, 255, 0.16);
+    border-radius: 999px;
+  }
+  .rail-availability:hover { border-color: rgba(247, 147, 26, 0.5); }
+  .rail-availability-dot {
+    width: 7px;
+    height: 7px;
+    border-radius: 50%;
+    background: #3fb950;
+    box-shadow: 0 0 0 3px rgba(63, 185, 80, 0.18);
+  }
+  .rail-social {
+    display: flex;
+    gap: 1.1rem;
+    font-family: var(--font-mono);
+    font-size: 0.8rem;
+  }
+  .rail-social a {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+    color: #9a9a9a;
+    text-decoration: none;
+    transition: color 0.2s ease;
+  }
+  .rail-social img {
+    width: 15px;
+    height: 15px;
+    filter: brightness(0) invert(1);
+    opacity: 0.65;
+    transition: opacity 0.2s ease;
+  }
+  .rail-social a:hover { color: #fff; }
+  .rail-social a:hover img { opacity: 1; }
+
+  @media (max-width: 860px) {
+    .app-sidebar {
+      position: static;
+      height: auto;
+      overflow: visible;
+      flex-basis: auto;
+      align-self: stretch;
+    }
+  }
+  @media print {
+    .app-sidebar { display: none; }
+  }
+</style>

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -1,5 +1,5 @@
 ---
-import Header from '../components/Header.astro';
+import Sidebar from '../components/Sidebar.astro';
 import BaseHead from '../components/BaseHead.astro';
 import '../styles/global.css';
 
@@ -12,6 +12,7 @@ interface Props {
 }
 
 const { title, description, image, type, publishedDate } = Astro.props;
+const isHome = Astro.url.pathname === '/';
 ---
 
 <!doctype html>
@@ -26,9 +27,11 @@ const { title, description, image, type, publishedDate } = Astro.props;
     />
   </head>
   <body>
-    <Header />
-    <main>
-      <slot />
-    </main>
+    <div class="app-shell">
+      <Sidebar isHome={isHome} />
+      <main>
+        <slot />
+      </main>
+    </div>
   </body>
 </html>

--- a/src/layouts/CvLayout.astro
+++ b/src/layouts/CvLayout.astro
@@ -1,8 +1,7 @@
 ---
-import Icon from '../components/Icon.astro';
+import Sidebar from '../components/Sidebar.astro';
 import BaseHead from '../components/BaseHead.astro';
 import '../styles/global.css';
-import { SOCIAL } from '../consts';
 
 interface Props {
   title?: string;
@@ -19,27 +18,17 @@ const { title, description, tagline } = Astro.props;
     <BaseHead title={title} description={description} />
   </head>
   <body>
-    <header>
-      <div class="header-inner">
-        <h1 class="brand-name"><a href="https://petewatters.ie">Pete Watters</a></h1>
-        <nav class="cv-nav">
-          <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer" aria-label="GitHub" title="GitHub">
-            <Icon name="github" />
-          </a>
-          <a href={SOCIAL.STACKOVERFLOW} target="_blank" rel="noopener noreferrer" aria-label="StackOverflow" title="StackOverflow">
-            <Icon name="stackoverflow" />
-          </a>
-        </nav>
-      </div>
-    </header>
-    <main>
-      <div class="cv">
-        <div class="cv-intro">
-          <p class="tagline">{tagline}</p>
+    <div class="app-shell">
+      <Sidebar />
+      <main>
+        <div class="cv">
+          <div class="cv-intro">
+            <p class="tagline">{tagline}</p>
+          </div>
+          <slot />
         </div>
-        <slot />
-      </div>
-    </main>
+      </main>
+    </div>
     <script>
       document.querySelectorAll('.cv a[href]').forEach(a => {
         const href = a.getAttribute('href');

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -2,103 +2,13 @@
 import BaseLayout from '../layouts/BaseLayout.astro';
 import OpenSource from '../components/OpenSource.astro';
 import ContactSection from '../components/ContactSection.astro';
-import { SOCIAL } from '../consts';
 ---
 
 <BaseLayout
   title="Web3 Engineer"
   description="Pete Watters — Web3 engineer with a decade in crypto across Bitcoin, Stacks, Solana and EVM chains. Wallets, trading terminals, institutional interfaces, on web and mobile."
 >
-  <div class="home-shell">
-
-    <aside class="home-rail">
-      <div class="rail-top">
-        <img
-          class="rail-avatar"
-          src="https://github.com/pete-watters.png"
-          alt="Pete Watters"
-          width="92"
-          height="92"
-          loading="eager"
-        />
-        <p class="rail-name">Pete Watters</p>
-        <h1 class="rail-title"><span class="hl-accent">Web3</span> Engineer</h1>
-          <p class="hero-rhythm rail-rhythm" aria-label="plan, build, ship">
-            <span class="rhythm-item">
-              <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <path d="m12.99 6.74 1.93 3.44" />
-                <path d="M19.136 12a10 10 0 0 1-14.271 0" />
-                <path d="m21 21-2.16-3.84" />
-                <path d="m3 21 8.02-14.26" />
-                <circle cx="12" cy="5" r="2" />
-              </svg>
-              <span>plan</span>
-            </span>
-            <span class="rhythm-sep" aria-hidden="true">·</span>
-            <span class="rhythm-item">
-              <svg class="rhythm-glyph" viewBox="0 0 24 24" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <path d="m15 12-9.373 9.373a1 1 0 0 1-3.001-3L12 9" />
-                <path d="m18 15 4-4" />
-                <path d="m21.5 11.5-1.914-1.914A2 2 0 0 1 19 8.172v-.344a2 2 0 0 0-.586-1.414l-1.657-1.657A6 6 0 0 0 12.516 3H9l1.243 1.243A6 6 0 0 1 12 8.485V10l2 2h1.172a2 2 0 0 1 1.414.586L18.5 14.5" />
-              </svg>
-              <span>build</span>
-            </span>
-            <span class="rhythm-sep" aria-hidden="true">·</span>
-            <span class="rhythm-item">
-              <svg class="rhythm-glyph" viewBox="0 0 24 24" width="16" height="16" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true" focusable="false">
-                <path d="M12 10.189V14" />
-                <path d="M12 2v3" />
-                <path d="M19 13V7a2 2 0 0 0-2-2H7a2 2 0 0 0-2 2v6" />
-                <path d="M19.38 20A11.6 11.6 0 0 0 21 14l-8.188-3.639a2 2 0 0 0-1.624 0L3 14a11.6 11.6 0 0 0 2.81 7.76" />
-                <path d="M2 21c.6.5 1.2 1 2.5 1 2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1s1.2 1 2.5 1c2.5 0 2.5-2 5-2 1.3 0 1.9.5 2.5 1" />
-              </svg>
-              <span>ship</span>
-            </span>
-          </p>
-          <p class="rail-bio">
-            Front end specialist with an eye for design. Passionate about UX and comfortable
-            delivering products across the stack. Building for the web for nearly 20 years —
-            the last decade in crypto.
-          </p>
-          <div class="rail-shipped">
-            <p class="rail-shipped-label">Shipped at</p>
-            <ul class="rail-shipped-list">
-              <li>Kraken</li>
-              <li>Fidelity</li>
-              <li>Bank of America</li>
-              <li>Xapo</li>
-              <li>Leather</li>
-              <li>Qredo</li>
-            </ul>
-          </div>
-      </div>
-
-      <nav class="rail-nav" aria-label="Primary">
-        <a href="/#work">Work</a>
-        <a href="/blog">Writing</a>
-        <a href="/cv">CV</a>
-      </nav>
-
-      <div class="rail-bottom">
-        <div class="hero-coins rail-coins" aria-hidden="true">
-          <span class="coin coin--btc"><img class="coin-face" src="/img/tokens/btc.svg" alt="" width="48" height="48" loading="lazy" /></span>
-          <span class="coin coin--eth"><img class="coin-face" src="/img/tokens/eth.svg" alt="" width="48" height="48" loading="lazy" /></span>
-          <span class="coin coin--stx"><img class="coin-face" src="/img/tokens/stx.svg" alt="" width="48" height="48" loading="lazy" /></span>
-          <span class="coin coin--sol"><img class="coin-face" src="/img/tokens/sol.svg" alt="" width="48" height="48" loading="lazy" /></span>
-        </div>
-        <a class="rail-availability" href="#contact">
-          <span class="rail-availability-dot" aria-hidden="true"></span>
-          Available for remote work 09/26
-        </a>
-        <div class="rail-social">
-          <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer"><img src="/img/social/github.svg" alt="" width="15" height="15" />GitHub</a>
-          <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer"><img src="/img/social/x.svg" alt="" width="15" height="15" />X</a>
-          <a href={SOCIAL.LINKEDIN} target="_blank" rel="noopener noreferrer"><img src="/img/social/linkedin.svg" alt="" width="15" height="15" />LinkedIn</a>
-        </div>
-      </div>
-    </aside>
-
-    <article class="homepage home-body">
+  <article class="homepage">
 
     <section class="case-studies" id="work">
       <p class="section-label">Case Studies</p>
@@ -330,8 +240,7 @@ import { SOCIAL } from '../consts';
 
     <ContactSection />
 
-    </article>
-  </div>
+  </article>
 </BaseLayout>
 
 <script>
@@ -367,33 +276,11 @@ import { SOCIAL } from '../consts';
 </script>
 
 <style>
-  :global(body:has(.home-shell) header.site-header) { display: none; }
-
-  :global(main:has(> .home-shell)) {
-    max-width: none;
-    padding: 0;
-    text-align: left;
-  }
-
-  .home-shell {
+  .homepage {
     --color-accent: #F7931A;
     --ease-out-soft: cubic-bezier(0.16, 1, 0.3, 1);
-    display: flex;
-    align-items: stretch;
+    max-width: 1180px;
     text-align: left;
-  }
-
-  .home-body {
-    flex: 1 1 auto;
-    min-width: 0;
-    max-width: none;
-    margin: 0;
-    padding: 3.25rem clamp(1.5rem, 5vw, 4rem) 4rem;
-  }
-
-  .home-body > section,
-  .home-body > :global(*) {
-    max-width: 1120px;
   }
 
   .homepage section { margin-bottom: 5rem; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -113,6 +113,28 @@ main {
   text-align: center;
 }
 
+/* App shell — persistent sidebar + content column */
+.app-shell {
+  display: flex;
+  align-items: flex-start;
+}
+.app-shell > main {
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 880px;
+  margin: 0 auto;
+  padding: 2.75rem clamp(1.5rem, 4vw, 3rem) 4rem;
+  text-align: left;
+}
+.app-shell > main:has(> .homepage) {
+  max-width: none;
+  margin: 0;
+}
+@media (max-width: 860px) {
+  .app-shell { flex-direction: column; }
+  .app-shell > main { max-width: none; margin: 0; }
+}
+
 /* Site header — sticky, full-width dark bar */
 header.site-header {
   position: sticky;


### PR DESCRIPTION
Extract the sidebar into a shared component; render it on every page via BaseLayout + CvLayout so blog, case studies and CV match the home. Sticky on scroll; homepage full-width, inner pages a wider centred column.