### PR TITLE
Mobile compact sidebar + cleaner breadcrumbs

### DIFF
--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -8,7 +8,7 @@ const { isHome = false } = Astro.props;
 const Title = isHome ? 'h1' : 'p';
 ---
 
-<aside class="app-sidebar">
+<aside class:list={["app-sidebar", { "is-home": isHome }]}>
   <div class="rail-top">
     <a class="rail-avatar-link" href="/" aria-label="Pete Watters — home">
       <img
@@ -260,13 +260,49 @@ const Title = isHome ? 'h1' : 'p';
   .rail-social a:hover img { opacity: 1; }
 
   @media (max-width: 860px) {
-    .app-sidebar {
+    /* Homepage keeps the full identity stacked on top. */
+    .app-sidebar.is-home {
       position: static;
       height: auto;
       overflow: visible;
       flex-basis: auto;
       align-self: stretch;
     }
+
+    /* Inner pages collapse to a compact sticky top bar so content is
+       immediately visible — avatar, name and nav only. */
+    .app-sidebar:not(.is-home) {
+      position: sticky;
+      top: 0;
+      z-index: 50;
+      height: auto;
+      overflow: visible;
+      flex-basis: auto;
+      align-self: stretch;
+      flex-direction: row;
+      align-items: center;
+      gap: 0.75rem;
+      padding: 0.55rem 1rem;
+      border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+    }
+    .app-sidebar:not(.is-home) .rail-top {
+      flex-direction: row;
+      align-items: center;
+      gap: 0.6rem;
+    }
+    .app-sidebar:not(.is-home) .rail-avatar { width: 32px; height: 32px; margin: 0; }
+    .app-sidebar:not(.is-home) .rail-name { margin: 0; font-size: 0.85rem; color: #fff; }
+    .app-sidebar:not(.is-home) .rail-title,
+    .app-sidebar:not(.is-home) .rail-rhythm,
+    .app-sidebar:not(.is-home) .rail-bio,
+    .app-sidebar:not(.is-home) .rail-shipped,
+    .app-sidebar:not(.is-home) .rail-bottom { display: none; }
+    .app-sidebar:not(.is-home) .rail-nav {
+      flex-direction: row;
+      gap: 1.1rem;
+      margin-left: auto;
+    }
+    .app-sidebar:not(.is-home) .rail-nav a { font-size: 0.9rem; padding: 0; }
   }
   @media print {
     .app-sidebar { display: none; }

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -319,30 +319,38 @@ header .brand-name {
 
 /* Breadcrumbs — standalone nav on blog pages */
 .breadcrumbs {
-  font-family: var(--font-sans);
-  font-size: 13px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  letter-spacing: 0.02em;
   color: var(--color-faint);
   text-align: left;
-  margin-bottom: 1.5rem;
+  margin-bottom: 2.25rem;
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
 }
 
 .breadcrumbs a {
   color: var(--color-muted);
   text-decoration: none;
   font-size: inherit;
+  border-bottom: 1px solid transparent;
+  transition: color 0.2s ease, border-color 0.2s ease;
 }
 
 .breadcrumbs a:hover {
   color: var(--color-text);
+  border-bottom-color: #f7931a;
 }
 
 .breadcrumb-sep {
-  margin: 0 0.3em;
+  margin: 0 0.5em;
   color: var(--color-faint);
+  opacity: 0.6;
 }
 
 .breadcrumb-current {
-  color: var(--color-faint);
+  color: var(--color-text);
 }
 
 .profile-avatar {


### PR DESCRIPTION
On mobile, inner pages collapse the sidebar to a compact sticky bar (avatar + name + nav) so content is immediately visible (no tall sidebar to scroll past); the homepage keeps its full identity hero. Restyle blog breadcrumbs (mono, clearer current state, wider margin).