### PR TITLE
Qredo role + sidebar/contact tweaks

### DIFF
--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -9,7 +9,7 @@ const EMAIL = 'hello@petewatters.ie';
 <section class="contact-section" id="contact" aria-labelledby="contact-label">
   <p class="section-label" id="contact-label">Contact</p>
   <p class="contact-bio">
-    Ping me on <a href={`mailto:${EMAIL}`}>{EMAIL}</a>, or find me on
+    Contact me at <a href={`mailto:${EMAIL}`}>{EMAIL}</a>, or find me on
     <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer">GitHub</a>,
     <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer">X</a>,
     or <a href={SOCIAL.LINKEDIN} target="_blank" rel="noopener noreferrer">LinkedIn</a>.

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -56,18 +56,19 @@ const Title = isHome ? 'h1' : 'p';
     </p>
     <p class="rail-bio">
       Front end specialist with an eye for design. Passionate about UX and comfortable
-      delivering products across the stack. Building for the web for nearly 20 years —
-      the last decade in crypto.
+      across the stack. Building for the web for nearly 20 years — the last decade in crypto.
     </p>
     <div class="rail-shipped">
       <p class="rail-shipped-label">Shipped at</p>
       <ul class="rail-shipped-list">
-        <li>Kraken</li>
-        <li>Fidelity</li>
-        <li>Bank of America</li>
-        <li>Xapo</li>
         <li>Leather</li>
         <li>Qredo</li>
+        <li>Kraken</li>
+        <li>Xapo</li>
+        <li>Bank of America</li>
+        <li>Rocksteady</li>
+        <li>Kontainers</li>
+        <li>Fidelity</li>
       </ul>
     </div>
   </div>

--- a/src/content/cv/main.md
+++ b/src/content/cv/main.md
@@ -29,11 +29,11 @@ Engineer building for the web for nearly 20 years, the last decade in crypto —
 - Shipped the multi-chain NFT gallery in Leather (Stacks SIP-9 and Bitcoin ordinals, including video and audio playback) using an AI-assisted development workflow — accelerating delivery while maintaining the wallet's review and testing standards.
 - Early AI-tooling adopter on the engineering team: established working patterns with Claude Code and Codex, contributing to CLAUDE.md and reusable skills that extended AI fluency across the team.
 
-### [Qredo](https://www.qredo.com) · Senior Frontend Engineer *Jan — Jun 2023 · Remote*
+### [Qredo](https://www.qredo.com) · Web3 Lead Developer *Jan — Jun 2023 · Remote*
 
 > Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network.
 
-- Directed Web3 wallet integration and developed a new institutional trading interface using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
+- Lead frontend developer for the Web3 wallet integration into Qredo's rebranded institutional UI, using React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and WebAPI to support secure client transactions on the Qredo network.
 - Developed a Node.js ETH transaction parser to present on-chain history in a human-readable format, improving compliance and operational transparency.
 
 ### [Kraken](https://www.kraken.com) · Cryptowatch · Senior Frontend Engineer *Aug 2020 — Nov 2022 · Remote*

--- a/src/content/work/qredo.md
+++ b/src/content/work/qredo.md
@@ -1,10 +1,10 @@
 ---
 title: "Qredo"
 company: "Qredo"
-role: "Senior Frontend Engineer"
+role: "Web3 Lead Developer"
 period: "January — June 2023"
-stat: "Greenfield to shipped in six months"
-headline: "Institutional DeFi trading interface, shipped in six months."
+stat: "Led Web3 wallet integration — MetaMask + WalletConnect — into the rebranded UI"
+headline: "Led Web3 wallet integration into a rebranded institutional DeFi platform."
 subtitle: "Qredo was a Layer 2 decentralised custodian protocol for institutional private key management on a blockchain network."
 confidentiality: "This case study describes my personal contributions as a contractor at Qredo. Some details have been omitted to respect confidentiality obligations. Details reflect my own experience and do not represent official Qredo communications."
 tech:
@@ -17,26 +17,26 @@ tech:
   - WalletConnect
   - Ethereum
 order: 6
-outcomeText: "Full institutional trading interface built from zero · MetaMask and WalletConnect integration live · Node.js ETH transaction parser delivered for compliance."
+outcomeText: "Led the frontend Web3 wallet integration (MetaMask, WalletConnect) into Qredo's rebranded UI · Node.js ETH transaction parser delivered for compliance."
 ---
 
 ## Overview
 
-Qredo was a Layer 2 institutional custodian protocol — the part of the stack that institutional asset managers use to hold and move on-chain assets without surrendering custody of their private keys. I joined as a senior frontend engineer in January 2023 for a six-month engagement.
+Qredo was a Layer 2 institutional custodian protocol — the part of the stack that institutional asset managers use to hold and move on-chain assets without surrendering custody of their private keys. I joined in January 2023 for a six-month engagement, as lead frontend developer for the Web3 wallet integration into Qredo's newly rebranded UI.
 
 ## The problem
 
 Two distinct pieces.
 
-The platform needed a new institutional trading interface — somewhere asset managers could place trades, view balances, and connect external wallets. None of that existed yet.
+Qredo was rolling out a rebranded UI, and the trading experience needed Web3 wallet connectivity — somewhere institutional clients could connect external wallets and sign transactions on the Qredo network.
 
 Compliance teams also needed a way to audit on-chain Ethereum activity in human-readable form. The raw transaction format is unforgiving — addresses, nonces, hex data — and not something a compliance analyst can sign off on at speed.
 
 ## What I built
 
-### Chapter 1 — The institutional trading interface
+### Chapter 1 — Web3 wallet integration
 
-Built the trading interface from scratch in React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and the Qredo WebAPI so institutional clients could sign transactions on the Qredo network without leaving the app.
+As lead frontend developer, I drove the Web3 wallet integration into the rebranded trading UI — React, Redux Toolkit, Material UI and styled-components. Integrated MetaMask, WalletConnect and the Qredo WebAPI so institutional clients could connect their wallets and sign transactions on the Qredo network without leaving the app.
 
 The institutional context shaped every decision — the interface had to be auditable, the wallet flows had to handle multi-sig approval explicitly, and the data flow had to make confusion impossible. There's a different bar for trading interfaces that move other people's money.
 

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -133,13 +133,13 @@ import ContactSection from '../components/ContactSection.astro';
             <span class="case-card-period">Jan — Jun 2023</span>
           </p>
           <h3 class="case-card-headline">
-            Greenfield institutional DeFi trading interface — blank repo to shipped in six months.
+            Led Web3 wallet integration into a rebranded DeFi platform.
           </h3>
           <p class="case-card-body">
-            Layer 2 institutional custodian protocol for private-key management. I directed
-            Web3 wallet integration and built a new institutional trading interface — React,
-            Redux Toolkit, MetaMask and WalletConnect — plus a Node.js parser that turns raw
-            ETH transactions into human-readable history for compliance teams.
+            Layer 2 institutional custodian protocol for private-key management. As lead
+            frontend developer, I drove the Web3 wallet integration (MetaMask, WalletConnect)
+            into the rebranded UI — React, Redux Toolkit — plus a Node.js parser that turns
+            raw ETH transactions into human-readable history for compliance teams.
           </p>
           <ul class="tags case-card-tags">
             <li>Ethereum</li>


### PR DESCRIPTION
Qredo reframed as Web3 Lead Developer (led Web3 wallet integration into the rebranded UI) across case study, homepage card and CV. Sidebar bio tightened; Shipped-at gains Rocksteady + Kontainers, ordered latest-first. Contact 'Ping me on' -> 'Contact me at'.