### PR TITLE
Sync main CI commits into dev (resolve release conflicts)

### DIFF
--- a/.github/workflows/code-checks.yml
+++ b/.github/workflows/code-checks.yml
@@ -5,6 +5,10 @@ on:
     branches: [main]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,10 @@ on:
     branches: [main, dev]
   pull_request:
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   deploy:
     runs-on: ubuntu-latest

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -4,6 +4,10 @@ on:
   pull_request:
     branches: [main]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   playwright:
     runs-on: ubuntu-latest
@@ -20,7 +24,16 @@ jobs:
           cache: npm
       - run: npm ci
       - run: npm run build
-      - run: npx playwright install --with-deps
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-all-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright system deps (always)
+        run: npx playwright install-deps
+      - name: Install Playwright browser binaries (skip if cached)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install
       - run: npx playwright test --shard=${{ matrix.shardIndex }}/${{ matrix.shardTotal }}
       - uses: actions/upload-artifact@v4
         if: ${{ !cancelled() }}

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -1,0 +1,53 @@
+# Bootstrap or refresh visual-regression baselines on Linux CI, where the
+# main `Visual Regression` workflow runs. Snapshots are platform-specific —
+# Mac-generated PNGs won't match Linux Chromium output, so they must be
+# generated in CI to be the canonical baseline.
+#
+# Trigger manually from the Actions tab → "Update visual baselines" →
+# Run workflow → pick the branch. The job runs Playwright with
+# --update-snapshots, then commits and pushes any new/changed PNGs in
+# e2e/__screenshots__ back to the branch.
+#
+# Use when:
+#   - First-run bootstrap (no baselines exist yet)
+#   - Intentional design change — current renders are correct, baselines stale
+
+name: Update visual baselines
+
+on:
+  workflow_dispatch:
+
+jobs:
+  update-baselines:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install chromium --with-deps
+      - run: npm run build
+      - run: npx bddgen --config playwright.bdd.config.ts
+      - name: Regenerate snapshots
+        run: npx playwright test --config playwright.bdd.config.ts --update-snapshots
+        env:
+          CI: 'true'
+      - name: Commit + push updated baselines
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add e2e/__screenshots__
+          if git diff --staged --quiet; then
+            echo "No baseline changes."
+          else
+            git commit -m "chore(e2e): refresh visual-regression baselines [skip ci]"
+            git push
+          fi

--- a/.github/workflows/update-visual-baselines.yml
+++ b/.github/workflows/update-visual-baselines.yml
@@ -33,7 +33,16 @@ jobs:
           node-version: 22
           cache: npm
       - run: npm ci
-      - run: npx playwright install chromium --with-deps
+      - uses: actions/cache@v4
+        id: playwright-cache
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-chromium-${{ runner.os }}-${{ hashFiles('package-lock.json') }}
+      - name: Install Playwright system deps (always)
+        run: npx playwright install-deps chromium
+      - name: Install Playwright Chromium binary (skip if cached)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: npx playwright install chromium
       - run: npm run build
       - run: npx bddgen --config playwright.bdd.config.ts
       - name: Regenerate snapshots
@@ -48,6 +57,11 @@ jobs:
           if git diff --staged --quiet; then
             echo "No baseline changes."
           else
-            git commit -m "chore(e2e): refresh visual-regression baselines [skip ci]"
-            git push
+            # No [skip ci]: let the regular Visual Regression workflow assert
+            # against the new baselines on this same commit. If it passes, the
+            # bootstrap actually worked; no need for a manual empty commit to
+            # validate.
+            git commit -m "chore(e2e): refresh visual-regression baselines"
+            # Explicit ref to avoid detached-HEAD / upstream-tracking ambiguity.
+            git push origin "HEAD:${GITHUB_REF_NAME}"
           fi

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ dist/
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# private working notes — never push
+.private/


### PR DESCRIPTION
Brings main's CI commits (#78, #83) into dev so the dev→main release PR (#102) is conflict-free. Keep dev's .gitignore (playwright-bdd ignores); take main's improved update-visual-baselines workflow (Playwright cache, no [skip ci]).