### PR TITLE
feat(cv): print-only identity header on CV page

### DIFF
--- a/src/layouts/CvLayout.astro
+++ b/src/layouts/CvLayout.astro
@@ -1,6 +1,7 @@
 ---
 import Sidebar from '../components/Sidebar.astro';
 import BaseHead from '../components/BaseHead.astro';
+import { SOCIAL } from '../consts';
 import '../styles/global.css';
 
 interface Props {
@@ -22,6 +23,16 @@ const { title, description, tagline } = Astro.props;
       <Sidebar />
       <main>
         <div class="cv">
+          <header class="cv-print-header">
+            <p class="cv-print-name">Pete Watters</p>
+            <p class="cv-print-title">Senior Software Engineer · React / TypeScript / Next.js · Bitcoin & Web3 · Dublin, Ireland</p>
+            <p class="cv-print-links">
+              <a href="https://petewatters.ie">petewatters.ie</a> ·
+              <a href={SOCIAL.LINKEDIN}>linkedin.com/in/pete-watters</a> ·
+              <a href={SOCIAL.GITHUB}>github.com/pete-watters</a> ·
+              <a href="mailto:pete@cteic.ie">pete@cteic.ie</a>
+            </p>
+          </header>
           <div class="cv-intro">
             <p class="tagline">{tagline}</p>
           </div>
@@ -42,42 +53,8 @@ const { title, description, tagline } = Astro.props;
 </html>
 
 <style>
-  header {
-    display: block;
-    padding: 1rem 2rem;
-    background-color: #2B2B2B;
-    color: white;
-    -webkit-print-color-adjust: exact;
-    print-color-adjust: exact;
-  }
-
-  header :global(a) {
-    color: white;
-  }
-
-  .header-inner {
-    max-width: 52rem;
-    margin: 0 auto;
-    padding: 0;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-  }
-
-  .header-inner :global(h1) {
-    margin: 0;
-    text-align: left;
-  }
-
-  .cv-nav {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-  }
-
-  .cv-nav :global(svg) {
-    width: 18px;
-    height: 18px;
+  .cv-print-header {
+    display: none;
   }
 
   main {
@@ -202,23 +179,42 @@ const { title, description, tagline } = Astro.props;
 
   /* Print styles */
   @media print {
-    header {
-      padding: 0.5rem 1rem;
-      background-color: #2B2B2B !important;
-      color: white !important;
+    .cv-print-header {
+      display: block;
+      margin-bottom: 0.6rem;
+      padding-bottom: 0.4rem;
+      border-bottom: 2px solid #111111;
     }
 
-    header :global(a) {
-      color: white !important;
-    }
-
-    header :global(h1) {
+    .cv-print-header .cv-print-name {
+      font-family: 'Space Grotesk', var(--font-sans);
       font-size: 1.5rem;
+      font-weight: 700;
+      line-height: 1.2;
+      letter-spacing: -0.01em;
+      color: #111111;
+      margin: 0 0 0.15rem;
     }
 
-    .cv-nav :global(svg) {
-      width: 14px;
-      height: 14px;
+    .cv-print-header .cv-print-title {
+      font-family: var(--font-sans);
+      font-size: 0.8rem;
+      line-height: 1.4;
+      color: #333333;
+      margin: 0 0 0.2rem;
+    }
+
+    .cv-print-header .cv-print-links {
+      font-family: var(--font-sans);
+      font-size: 0.72rem;
+      line-height: 1.4;
+      color: #555555;
+      margin: 0;
+    }
+
+    .cv-print-header .cv-print-links a {
+      color: #555555;
+      text-decoration: none;
     }
 
     main {
@@ -226,8 +222,7 @@ const { title, description, tagline } = Astro.props;
     }
 
     .cv-intro {
-      margin-bottom: 0.5rem;
-      padding-bottom: 0.5rem;
+      display: none;
     }
 
     .tagline {

--- a/tests/e2e/cv.spec.ts
+++ b/tests/e2e/cv.spec.ts
@@ -39,6 +39,25 @@ test.describe('CV page', () => {
     expect(response.status()).toBe(200);
   });
 
+  test.describe('print header', () => {
+    test('identity header is hidden on screen', async ({ page }) => {
+      await page.goto('/cv');
+      await expect(page.locator('.cv-print-header')).toBeHidden();
+    });
+
+    test('identity header appears when printing with name, title and contacts', async ({ page }) => {
+      await page.goto('/cv');
+      await page.emulateMedia({ media: 'print' });
+      const header = page.locator('.cv-print-header');
+      await expect(header).toBeVisible();
+      await expect(header).toContainText('Pete Watters');
+      await expect(header).toContainText('Senior Software Engineer');
+      await expect(header).toContainText('petewatters.ie');
+      await expect(header).toContainText('github.com/pete-watters');
+      await expect(header.locator('a[href="mailto:pete@cteic.ie"]')).toBeVisible();
+    });
+  });
+
   test.describe('old variant URLs redirect to /cv/', () => {
     for (const variant of ['full-stack', 'frontend', 'product']) {
       test(`/cv/${variant} redirects to /cv/`, async ({ page }) => {


### PR DESCRIPTION
## Summary

- The CV page is printed to PDF, but the printed output lost the name and contact links — those live in the sidebar, which is `display:none` in print.
- Add a bespoke **print-only** identity header to the CV page: name, a `Senior Software Engineer · React / TypeScript / Next.js · Bitcoin & Web3 · Dublin, Ireland` line, and contact links (petewatters.ie, LinkedIn, GitHub, email). Hidden on screen (the sidebar already carries identity there).
- Hide the redundant on-screen tagline when printing, since the new header sub-line supersedes it.
- Remove dead `header` / `.header-inner` / `.cv-nav` styles in `CvLayout` that matched no element (and would otherwise have clobbered the new header).
- Add e2e coverage: header is hidden on screen and visible with name/title/contacts under print media.

## Linked issue

Type: chore/fix — CV print fidelity. No tracking issue.

## Note

The functional e2e suite has 24 pre-existing failures on `dev` (stale assertions from the rebrand, e.g. home expects 4 case-study cards but there are now 7, and the CV spec still asserts old summary copy). This PR adds no new failures — verified against a clean `dev` baseline (24 failed / 57 passed, identical with and without this change). Worth a separate cleanup pass.