### PR TITLE
feat(transitions): site-wide View Transitions with avatar morph

### DIFF
--- a/src/components/BaseHead.astro
+++ b/src/components/BaseHead.astro
@@ -1,4 +1,5 @@
 ---
+import { ClientRouter } from 'astro:transitions';
 import { SITE_TITLE, SITE_DESCRIPTION, SOCIAL } from '../consts';
 
 interface Props {
@@ -47,6 +48,8 @@ const jsonLd =
 <meta name="description" content={pageDescription} />
 <link rel="canonical" href={canonicalURL} />
 <link rel="alternate" type="application/rss+xml" title={SITE_TITLE} href="/rss.xml" />
+
+<ClientRouter />
 
 <link rel="preconnect" href="https://fonts.googleapis.com" />
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/src/components/Search.astro
+++ b/src/components/Search.astro
@@ -3,5 +3,12 @@
 <script>
   // @ts-ignore — no type declarations for pagefind
   import { PagefindUI } from '@pagefind/default-ui';
-  new PagefindUI({ element: '#search', showSubResults: true });
+  function initSearch() {
+    const el = document.querySelector('#search');
+    if (el instanceof HTMLElement && !el.dataset.pagefindReady) {
+      new PagefindUI({ element: '#search', showSubResults: true });
+      el.dataset.pagefindReady = 'true';
+    }
+  }
+  document.addEventListener('astro:page-load', initSearch);
 </script>

--- a/src/components/Sidebar.astro
+++ b/src/components/Sidebar.astro
@@ -18,6 +18,7 @@ const Title = isHome ? 'h1' : 'p';
         width="92"
         height="92"
         loading="eager"
+        transition:name="pw-avatar"
       />
     </a>
     <p class="rail-name">Pete Watters</p>

--- a/src/layouts/CvLayout.astro
+++ b/src/layouts/CvLayout.astro
@@ -30,13 +30,16 @@ const { title, description, tagline } = Astro.props;
       </main>
     </div>
     <script>
-      document.querySelectorAll('.cv a[href]').forEach(a => {
-        const href = a.getAttribute('href');
-        if (href && (href.startsWith('http') || href.startsWith('//'))) {
-          a.setAttribute('target', '_blank');
-          a.setAttribute('rel', 'noopener noreferrer');
-        }
-      });
+      function markCvExternalLinks() {
+        document.querySelectorAll('.cv a[href]').forEach(a => {
+          const href = a.getAttribute('href');
+          if (href && (href.startsWith('http') || href.startsWith('//'))) {
+            a.setAttribute('target', '_blank');
+            a.setAttribute('rel', 'noopener noreferrer');
+          }
+        });
+      }
+      document.addEventListener('astro:page-load', markCvExternalLinks);
     </script>
   </body>
 </html>

--- a/src/pages/blog/[slug].astro
+++ b/src/pages/blog/[slug].astro
@@ -40,11 +40,14 @@ const { Content } = await render(post);
 </BaseLayout>
 
 <script>
-  document.querySelectorAll('.blog-post a[href]').forEach(a => {
-    const href = a.getAttribute('href');
-    if (href && (href.startsWith('http') || href.startsWith('//'))) {
-      a.setAttribute('target', '_blank');
-      a.setAttribute('rel', 'noopener noreferrer');
-    }
-  });
+  function markPostExternalLinks() {
+    document.querySelectorAll('.blog-post a[href]').forEach(a => {
+      const href = a.getAttribute('href');
+      if (href && (href.startsWith('http') || href.startsWith('//'))) {
+        a.setAttribute('target', '_blank');
+        a.setAttribute('rel', 'noopener noreferrer');
+      }
+    });
+  }
+  document.addEventListener('astro:page-load', markPostExternalLinks);
 </script>

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -58,52 +58,48 @@ const allTags = [...new Set(allPosts.flatMap((post: CollectionEntry<'blog'>) => 
 </BaseLayout>
 
 <script>
-  function initTagFilter() {
+  function filterByTag(tag: string) {
     const buttons = document.querySelectorAll<HTMLButtonElement>('.tag-filters button');
     const cards = document.querySelectorAll<HTMLElement>('.blog-card');
     const featuredSection = document.querySelector<HTMLElement>('.featured-section');
 
-    function filterByTag(tag: string) {
-      buttons.forEach((btn) => btn.setAttribute('aria-pressed', String(btn.dataset.tag === tag)));
+    buttons.forEach((btn) => btn.setAttribute('aria-pressed', String(btn.dataset.tag === tag)));
 
-      if (tag === 'all') {
-        cards.forEach((card) => card.removeAttribute('hidden'));
-        if (featuredSection) featuredSection.removeAttribute('hidden');
-      } else {
-        let anyFeaturedVisible = false;
-        cards.forEach((card) => {
-          const cardTags = card.dataset.tags?.split(',') ?? [];
-          const matches = cardTags.includes(tag);
-          if (matches) {
-            card.removeAttribute('hidden');
-            if (featuredSection?.contains(card)) anyFeaturedVisible = true;
-          } else {
-            card.setAttribute('hidden', '');
-          }
-        });
-        if (featuredSection) {
-          if (anyFeaturedVisible) {
-            featuredSection.removeAttribute('hidden');
-          } else {
-            featuredSection.setAttribute('hidden', '');
-          }
+    if (tag === 'all') {
+      cards.forEach((card) => card.removeAttribute('hidden'));
+      if (featuredSection) featuredSection.removeAttribute('hidden');
+    } else {
+      let anyFeaturedVisible = false;
+      cards.forEach((card) => {
+        const cardTags = card.dataset.tags?.split(',') ?? [];
+        const matches = cardTags.includes(tag);
+        if (matches) {
+          card.removeAttribute('hidden');
+          if (featuredSection?.contains(card)) anyFeaturedVisible = true;
+        } else {
+          card.setAttribute('hidden', '');
+        }
+      });
+      if (featuredSection) {
+        if (anyFeaturedVisible) {
+          featuredSection.removeAttribute('hidden');
+        } else {
+          featuredSection.setAttribute('hidden', '');
         }
       }
-
-      window.history.replaceState(null, '', tag === 'all' ? window.location.pathname : `#${tag}`);
     }
 
-    buttons.forEach((btn) => {
-      btn.addEventListener('click', () => filterByTag(btn.dataset.tag!));
-    });
+    window.history.replaceState(null, '', tag === 'all' ? window.location.pathname : `#${tag}`);
+  }
 
-    document.addEventListener('click', (e) => {
-      const link = (e.target as HTMLElement).closest<HTMLAnchorElement>('[data-filter-tag]');
-      if (link) {
-        e.preventDefault();
-        const tag = link.textContent?.trim();
+  function initTagFilter() {
+    const buttons = document.querySelectorAll<HTMLButtonElement>('.tag-filters button');
+
+    buttons.forEach((btn) => {
+      btn.addEventListener('click', () => {
+        const tag = btn.dataset.tag;
         if (tag) filterByTag(tag);
-      }
+      });
     });
 
     const hash = window.location.hash.slice(1);
@@ -114,7 +110,17 @@ const allTags = [...new Set(allPosts.flatMap((post: CollectionEntry<'blog'>) => 
     }
   }
 
-  initTagFilter();
+  document.addEventListener('click', (e) => {
+    const target = e.target;
+    const link = target instanceof Element ? target.closest<HTMLAnchorElement>('[data-filter-tag]') : null;
+    if (link) {
+      e.preventDefault();
+      const tag = link.textContent?.trim();
+      if (tag) filterByTag(tag);
+    }
+  });
+
+  document.addEventListener('astro:page-load', initTagFilter);
 </script>
 
 <style>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -329,35 +329,39 @@ import ContactSection from '../components/ContactSection.astro';
 </BaseLayout>
 
 <script>
-  const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
+  function initReveal() {
+    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
 
-  if (!reduceMotion && 'IntersectionObserver' in window) {
-    const observer = new IntersectionObserver((entries) => {
-      entries.forEach((entry) => {
-        if (entry.isIntersecting) {
-          const delay = Number(entry.target.getAttribute('data-stagger') || 0);
-          setTimeout(() => entry.target.classList.add('is-visible'), delay);
-          observer.unobserve(entry.target);
-        }
+    if (!reduceMotion && 'IntersectionObserver' in window) {
+      const observer = new IntersectionObserver((entries) => {
+        entries.forEach((entry) => {
+          if (entry.isIntersecting) {
+            const delay = Number(entry.target.getAttribute('data-stagger') || 0);
+            setTimeout(() => entry.target.classList.add('is-visible'), delay);
+            observer.unobserve(entry.target);
+          }
+        });
+      }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
+
+      const groups = [
+        { selector: '.logo-strip-list [data-reveal]', step: 80 },
+        { selector: '.case-card[data-reveal]',        step: 120 },
+        { selector: '.timeline-row[data-reveal]',     step: 60 },
+      ];
+
+      groups.forEach(({ selector, step }) => {
+        document.querySelectorAll(selector).forEach((el, i) => {
+          el.setAttribute('data-stagger', String(i * step));
+        });
       });
-    }, { threshold: 0.12, rootMargin: '0px 0px -40px 0px' });
 
-    const groups = [
-      { selector: '.logo-strip-list [data-reveal]', step: 80 },
-      { selector: '.case-card[data-reveal]',        step: 120 },
-      { selector: '.timeline-row[data-reveal]',     step: 60 },
-    ];
-
-    groups.forEach(({ selector, step }) => {
-      document.querySelectorAll(selector).forEach((el, i) => {
-        el.setAttribute('data-stagger', String(i * step));
-      });
-    });
-
-    document.querySelectorAll('[data-reveal]').forEach((el) => observer.observe(el));
-  } else {
-    document.querySelectorAll('[data-reveal]').forEach((el) => el.classList.add('is-visible'));
+      document.querySelectorAll('[data-reveal]').forEach((el) => observer.observe(el));
+    } else {
+      document.querySelectorAll('[data-reveal]').forEach((el) => el.classList.add('is-visible'));
+    }
   }
+
+  document.addEventListener('astro:page-load', initReveal);
 </script>
 
 <style>


### PR DESCRIPTION
## Summary

- Adds **Astro View Transitions** (`ClientRouter`) site-wide via `BaseHead`, turning the static MPA into app-like, cross-fading navigation — fitting for a PWA.
- **Avatar morph**: a shared-element `transition:name` on the avatar. On mobile it morphs between the large home rail and the compact top bar; on desktop it's a seamless cross-fade.
- **Transition-safe scripts**: re-binds every interactive script on `astro:page-load` so nothing breaks after a client navigation — Pagefind search, blog tag filters, homepage scroll-reveal, and the CV/blog external-link rewriters.
- The tag-filter handler now re-queries the DOM per call and registers its delegated click listener once, eliminating stale element refs and listener leaks.

## Linked issue

Type: enhancement (no tracking issue) — demo for design review

## Note

This is one of several animation demos on individual branches for side-by-side preview. Visual-regression baselines aren't affected by transitions, but verify search + tag filters on the preview deploy (they need the built Pagefind index, which only exists after deploy).
