### PR TITLE
feat(home): first-visit NFT intro splash (once per session)

### DIFF
--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -13,6 +13,27 @@ interface Props {
 
 const { title, description, image, type, publishedDate } = Astro.props;
 const isHome = Astro.url.pathname === '/';
+
+const splashScript = `(function(){
+  try {
+    if (sessionStorage.getItem('pw-splash-seen')) return;
+    if (window.matchMedia('(prefers-reduced-motion: reduce)').matches) return;
+    sessionStorage.setItem('pw-splash-seen', '1');
+    var html = document.documentElement;
+    html.classList.add('pw-splash-active');
+    function dismiss(){
+      var s = document.querySelector('.pw-splash');
+      if (!s) { html.classList.remove('pw-splash-active'); return; }
+      setTimeout(function(){
+        s.classList.add('is-done');
+        setTimeout(function(){ html.classList.remove('pw-splash-active'); }, 600);
+      }, 1500);
+    }
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', dismiss);
+    } else { dismiss(); }
+  } catch (e) {}
+})();`;
 ---
 
 <!doctype html>
@@ -25,8 +46,14 @@ const isHome = Astro.url.pathname === '/';
       type={type}
       publishedDate={publishedDate}
     />
+    {isHome && <script is:inline set:html={splashScript} />}
   </head>
   <body>
+    {isHome && (
+      <div class="pw-splash" aria-hidden="true">
+        <img class="pw-splash-avatar" src="/img/icon.png" alt="" width="156" height="156" fetchpriority="high" />
+      </div>
+    )}
     <div class="app-shell">
       <Sidebar isHome={isHome} />
       <main>

--- a/src/styles/global.css
+++ b/src/styles/global.css
@@ -716,3 +716,40 @@ summary {
     margin-bottom: 0.15rem;
   }
 }
+
+html.pw-splash-active,
+html.pw-splash-active body {
+  overflow: hidden;
+}
+.pw-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 9999;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  background: #000;
+  opacity: 1;
+  perspective: 800px;
+  transition: opacity 0.55s ease;
+}
+html.pw-splash-active .pw-splash {
+  display: flex;
+}
+.pw-splash.is-done {
+  opacity: 0;
+  pointer-events: none;
+}
+.pw-splash-avatar {
+  width: clamp(104px, 18vw, 156px);
+  height: clamp(104px, 18vw, 156px);
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.1), 0 0 44px rgba(247, 147, 26, 0.45);
+  animation: pw-splash-spin 1.3s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+}
+@keyframes pw-splash-spin {
+  to { transform: rotateY(360deg); }
+}
+@media (prefers-reduced-motion: reduce) {
+  .pw-splash-avatar { animation: none; }
+}


### PR DESCRIPTION
## Summary

- A **first-visit intro splash on the home page**: a black full-screen overlay with the NFT avatar doing a coin-flip (`rotateY`) spin and an accent glow, fading out after ~1.5s.
- **Shows once per session** (`sessionStorage` gate) and only when `prefers-reduced-motion` is not set. Hidden by default and **JS opt-in**, so no-JS users never get a stuck black screen.
- Home-only (gated by `BaseLayout`'s `isHome`); an inline head script adds the active class before first paint to avoid a flash of content.

## Linked issue

Type: enhancement (no tracking issue) — gimmick demo for design review

## Note

In fresh browser sessions the overlay covers the home page for ~2s, so functional/visual e2e on `/` may need it disabled (pre-seed `sessionStorage['pw-splash-seen']` or run under reduced-motion) if we adopt it. Avatar source is `/img/icon.png` — easy to swap for the live Solana NFT fetch.
