### PR TITLE
ci: add one-button release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,115 @@
+# One-button release for the dev → main flow documented in CONTRIBUTING.md.
+#
+# Two halves:
+#   1. Actions tab → "Release" → Run workflow (pick a bump) — computes the
+#      next version from the latest semver tag (with package.json as a floor)
+#      and opens a dev → main PR titled "Release: <version>" with notes
+#      generated from the commits being promoted. Edit the body before
+#      merging if needed.
+#   2. When a PR from dev titled "Release: <version>" is merged into main,
+#      tags the merge commit with <version> and publishes a GitHub release
+#      using the PR body as notes. Deploy to production happens separately,
+#      via deploy.yml on push to main.
+#
+# The PR is created with GH_PAT rather than GITHUB_TOKEN — events created by
+# the default token don't trigger other workflows, so the release PR would
+# get no CI checks.
+
+name: Release
+
+on:
+  workflow_dispatch:
+    inputs:
+      bump:
+        description: 'Version bump'
+        type: choice
+        options:
+          - minor
+          - patch
+          - major
+        default: minor
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+jobs:
+  open-release-pr:
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: dev
+          fetch-depth: 0
+      - name: Skip if a release PR is already open
+        id: existing
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+        run: |
+          url=$(gh pr list --base main --head dev --state open --json url --jq '.[0].url // empty')
+          if [ -n "$url" ]; then
+            echo "::notice::A release PR is already open: $url"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          fi
+      - name: Compute next version
+        if: steps.existing.outputs.skip != 'true'
+        id: version
+        run: |
+          latest_tag=$(git tag --list | grep -E '^v?[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -1)
+          pkg_version=$(node -p "require('./package.json').version")
+          base=$(printf '%s\n%s\n' "${latest_tag:-0.0.0}" "$pkg_version" | sort -V | tail -1)
+          IFS=. read -r major minor patch <<< "$base"
+          case "${{ inputs.bump }}" in
+            major) next="$((major + 1)).0.0" ;;
+            minor) next="${major}.$((minor + 1)).0" ;;
+            patch) next="${major}.${minor}.$((patch + 1))" ;;
+          esac
+          echo "next=$next" >> "$GITHUB_OUTPUT"
+      - name: Open release PR
+        if: steps.existing.outputs.skip != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GH_PAT }}
+          VERSION: ${{ steps.version.outputs.next }}
+        run: |
+          notes=$(git log --cherry-pick --right-only --no-merges origin/main...HEAD --format='- %s')
+          body=$(printf '## Summary\n%s\n\n## Linked issue\nType: release (dev → main)\n\nMerging tags `%s`, publishes the GitHub release, and deploys production.' "$notes" "$VERSION")
+          gh pr create \
+            --base main \
+            --head dev \
+            --title "Release: $VERSION" \
+            --assignee pete-watters \
+            --body "$body"
+
+  tag-release:
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.ref == 'dev' &&
+      startsWith(github.event.pull_request.title, 'Release:')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.merge_commit_sha }}
+      - name: Tag merge commit and publish GitHub release
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TITLE: ${{ github.event.pull_request.title }}
+          BODY: ${{ github.event.pull_request.body }}
+          TARGET: ${{ github.event.pull_request.merge_commit_sha }}
+        run: |
+          version=$(printf '%s' "$TITLE" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -1)
+          if [ -z "$version" ]; then
+            echo "::warning::No semver version found in PR title '$TITLE'; skipping tag."
+            exit 0
+          fi
+          gh release create "$version" \
+            --target "$TARGET" \
+            --title "$version" \
+            --notes "$BODY"


### PR DESCRIPTION
## Summary
- New `release.yml` workflow with two halves:
  - **Button**: Actions tab → Release → Run workflow (choose major/minor/patch bump). Computes the next version from the latest semver tag with `package.json` as a floor, then opens a `dev → main` PR titled `Release: <version>` with notes generated from the commits being promoted. Skips politely if a release PR is already open.
  - **Tag on merge**: when a PR from `dev` titled `Release: <version>` merges into `main`, tags the squash commit and publishes a GitHub release using the PR body as notes. `deploy.yml` then ships production as usual on push to main.
- Release PR is created with `GH_PAT` (not `GITHUB_TOKEN`) so CI checks actually run on it — GitHub suppresses workflow triggers for events created by the default token

## Linked issue
Type: ci