### PR TITLE
test(e2e): reconcile specs with shipped redesigns; run integration tests on dev PRs

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -2,7 +2,7 @@ name: Integration Tests
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/tests/e2e/blog.spec.ts
+++ b/tests/e2e/blog.spec.ts
@@ -21,7 +21,7 @@ test.describe('Blog', () => {
 
   test('blog listing has correct title', async ({ page }) => {
     await page.goto('/blog');
-    await expect(page).toHaveTitle('Blog | Pete Watters');
+    await expect(page).toHaveTitle('Writing | Pete Watters');
   });
 
   test('has search element', async ({ page }) => {
@@ -37,7 +37,7 @@ test.describe('Blog', () => {
 
   test('tag filter "All" is selected by default', async ({ page }) => {
     await page.goto('/blog');
-    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-pressed', 'true');
   });
 
   test('clicking a tag filters posts', async ({ page }) => {
@@ -51,8 +51,8 @@ test.describe('Blog', () => {
     await firstTagButton.click();
 
     // The tag should now be selected
-    await expect(firstTagButton).toHaveAttribute('aria-selected', 'true');
-    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-selected', 'false');
+    await expect(firstTagButton).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-pressed', 'false');
 
     // At least one card should be visible
     const visibleCards = page.locator('.blog-card:not([hidden])');
@@ -75,7 +75,7 @@ test.describe('Blog', () => {
 
     // Reset
     await page.locator('.tag-filters button[data-tag="all"]').click();
-    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-selected', 'true');
+    await expect(page.locator('.tag-filters button[data-tag="all"]')).toHaveAttribute('aria-pressed', 'true');
 
     const visibleCards = page.locator('.blog-card:not([hidden])');
     expect(await visibleCards.count()).toBe(totalBefore);
@@ -92,7 +92,7 @@ test.describe('Blog', () => {
     const breadcrumbs = page.locator('.breadcrumbs');
     await expect(breadcrumbs).toBeVisible();
     await expect(breadcrumbs.locator('a[href="/"]')).toHaveText('Home');
-    await expect(breadcrumbs.locator('a[href="/blog"]')).toHaveText('Blog');
+    await expect(breadcrumbs.locator('a[href="/blog"]')).toHaveText('Writing');
   });
 
   test('blog cards have data-tags attribute', async ({ page }) => {

--- a/tests/e2e/cv.spec.ts
+++ b/tests/e2e/cv.spec.ts
@@ -4,7 +4,7 @@ test.describe('CV page', () => {
   test('/cv renders the unified CV', async ({ page }) => {
     await page.goto('/cv');
     await expect(page).toHaveTitle('CV | Pete Watters');
-    await expect(page.locator('.cv')).toContainText('Engineer with 15+ years');
+    await expect(page.locator('.cv')).toContainText('Engineer building for the web for nearly 20 years');
   });
 
   test('skills section renders with frontend groupings', async ({ page }) => {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -3,41 +3,41 @@ import { test, expect } from '@playwright/test';
 test.describe('Home page', () => {
   test('has correct title', async ({ page }) => {
     await page.goto('/');
-    await expect(page).toHaveTitle('Pete Watters');
+    await expect(page).toHaveTitle('Web3 Engineer | Pete Watters');
   });
 
-  test('header shows availability badge (not hero)', async ({ page }) => {
+  test('rail shows availability badge (not hero)', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.header-availability')).toContainText('Available Sep 2026');
+    await expect(page.locator('.rail-availability')).toContainText('Available for remote work');
     // Hero-scale availability badge is gone — should not exist
     await expect(page.locator('.hero .availability-badge')).toHaveCount(0);
   });
 
-  test('header has the primary nav links', async ({ page }) => {
+  test('rail has the primary nav links', async ({ page }) => {
     await page.goto('/');
-    const links = page.locator('header.site-header .primary-nav a');
+    const links = page.locator('.rail-nav a');
     await expect(links).toHaveCount(3);
     await expect(links.nth(0)).toHaveText('Work');
-    await expect(links.nth(1)).toHaveText('Blog');
+    await expect(links.nth(1)).toHaveText('Writing');
     await expect(links.nth(2)).toHaveText('CV');
   });
 
   test('hero no longer duplicates the Pete Watters wordmark', async ({ page }) => {
     await page.goto('/');
-    // .hero-name was removed; the header h1 a is the only wordmark
+    // .hero-name was removed; the rail name is the only wordmark
     await expect(page.locator('.hero-name')).toHaveCount(0);
-    await expect(page.locator('header.site-header h1 a')).toHaveText('Pete Watters');
+    await expect(page.locator('.rail-name')).toHaveText('Pete Watters');
   });
 
-  test('hero shows Engineer headline + plan/build/ship rhythm + bio', async ({ page }) => {
+  test('rail shows Web3 Engineer headline + plan/build/ship rhythm + bio', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.hero-headline')).toHaveText('Engineer');
+    await expect(page.locator('.rail-title')).toContainText('Web3 Engineer');
     const items = page.locator('.rhythm-item');
     await expect(items).toHaveCount(3);
     await expect(items.nth(0)).toContainText('plan');
     await expect(items.nth(1)).toContainText('build');
     await expect(items.nth(2)).toContainText('ship');
-    await expect(page.locator('.hero-bio')).toContainText('crypto products');
+    await expect(page.locator('.rail-bio')).toContainText('Building for the web');
   });
 
   test('rhythm items each have an inline monoline glyph SVG', async ({ page }) => {
@@ -46,12 +46,12 @@ test.describe('Home page', () => {
     await expect(glyphs).toHaveCount(3);
   });
 
-  test('logo strip lists all six companies', async ({ page }) => {
+  test('shipped-at strip lists all six companies', async ({ page }) => {
     await page.goto('/');
-    const items = page.locator('.logo-strip-list li');
+    const items = page.locator('.rail-shipped-list li');
     await expect(items).toHaveCount(6);
-    await expect(items.nth(0)).toHaveText('Kraken');
-    await expect(items.nth(5)).toHaveText('Qredo');
+    await expect(items.nth(0)).toHaveText('Leather');
+    await expect(items.nth(5)).toHaveText('Fidelity');
   });
 
   test('case studies section has id="work" so /#work anchor scrolls correctly', async ({ page }) => {
@@ -59,19 +59,23 @@ test.describe('Home page', () => {
     await expect(page.locator('section.case-studies#work')).toBeVisible();
   });
 
-  test('shows four case study cards', async ({ page }) => {
+  test('shows seven case study cards', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.case-card')).toHaveCount(4);
+    await expect(page.locator('.case-card')).toHaveCount(7);
   });
 
-  test('case study cards link to /work/<slug>/', async ({ page }) => {
+  test('case study cards link to /work/<slug>/ plus the repo', async ({ page }) => {
     await page.goto('/');
     const links = page.locator('.case-card-link');
-    await expect(links).toHaveCount(4);
-    await expect(links.nth(0)).toHaveAttribute('href', '/work/leather/');
+    await expect(links).toHaveCount(7);
+    await expect(links.nth(0)).toHaveAttribute('href', '/work/leather-mobile/');
     await expect(links.nth(1)).toHaveAttribute('href', '/work/cryptowatch/');
     await expect(links.nth(2)).toHaveAttribute('href', '/work/xapo/');
     await expect(links.nth(3)).toHaveAttribute('href', '/work/qredo/');
+    await expect(links.nth(4)).toHaveAttribute('href', '/work/stackr/');
+    await expect(links.nth(5)).toHaveAttribute('href', '/work/simplyfpl/');
+    await expect(links.nth(6)).toHaveAttribute('href', 'https://github.com/pete-watters/portfolio-pwa');
+    await expect(links.nth(6)).toHaveAttribute('target', '_blank');
   });
 
   test('timeline lists every role from Trust Machines back to Earlier', async ({ page }) => {
@@ -91,9 +95,9 @@ test.describe('Home page', () => {
     await expect(contact.locator('a[href*="x.com/petew_btc"]')).toBeVisible();
   });
 
-  test('header has no social icons (they moved to contact section)', async ({ page }) => {
+  test('rail nav has no social icons (they moved to contact section)', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('header.site-header a[href*="github.com"]')).toHaveCount(0);
-    await expect(page.locator('header.site-header a[href*="x.com"]')).toHaveCount(0);
+    await expect(page.locator('.rail-nav a[href*="github.com"]')).toHaveCount(0);
+    await expect(page.locator('.rail-nav a[href*="x.com"]')).toHaveCount(0);
   });
 });

--- a/tests/e2e/navigation.spec.ts
+++ b/tests/e2e/navigation.spec.ts
@@ -1,31 +1,31 @@
 import { test, expect } from '@playwright/test';
 
 test.describe('Navigation', () => {
-  test('header links to home', async ({ page }) => {
+  test('rail avatar links to home', async ({ page }) => {
     await page.goto('/blog');
-    await page.click('header h1 a');
+    await page.click('.rail-avatar-link');
     await expect(page).toHaveURL('/');
   });
 
-  test('nav shows social icons only', async ({ page }) => {
+  test('rail nav shows internal links and no social icons', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('nav a[href="/blog"]')).toHaveCount(0);
-    await expect(page.locator('nav a[href="/cv"]')).toHaveCount(0);
-    await expect(page.locator('nav a[aria-label="GitHub"]')).toBeVisible();
-    await expect(page.locator('nav a[aria-label="X"]')).toBeVisible();
-    await expect(page.locator('nav a[aria-label="StackOverflow"]')).toBeVisible();
+    await expect(page.locator('.rail-nav a[href="/blog"]')).toHaveCount(1);
+    await expect(page.locator('.rail-nav a[href="/cv"]')).toHaveCount(1);
+    await expect(page.locator('.rail-nav a[href*="github.com"]')).toHaveCount(0);
+    await expect(page.locator('.rail-nav a[href*="x.com"]')).toHaveCount(0);
   });
 
-  test('nav shows all three social icons', async ({ page }) => {
+  test('contact section shows the social links', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('nav a[aria-label="GitHub"]')).toBeVisible();
-    await expect(page.locator('nav a[aria-label="X"]')).toBeVisible();
-    await expect(page.locator('nav a[aria-label="StackOverflow"]')).toBeVisible();
+    const contact = page.locator('section#contact');
+    await expect(contact.locator('a[href*="github.com/pete-watters"]')).toBeVisible();
+    await expect(contact.locator('a[href*="x.com/petew_btc"]')).toBeVisible();
+    await expect(contact.locator('a[href*="linkedin.com/in/pete-watters"]')).toBeVisible();
   });
 
   test('social links open in new tab', async ({ page }) => {
     await page.goto('/');
-    const socialLinks = page.locator('nav a[target="_blank"]');
+    const socialLinks = page.locator('section#contact a[target="_blank"]');
     expect(await socialLinks.count()).toBe(3);
     for (const link of await socialLinks.all()) {
       await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
@@ -35,7 +35,7 @@ test.describe('Navigation', () => {
   test('404 page renders for unknown routes', async ({ page }) => {
     const response = await page.goto('/nonexistent-page');
     expect(response?.status()).toBe(404);
-    await expect(page.locator('h2')).toContainText('404');
+    await expect(page.locator('h1')).toContainText('404');
     await expect(page.getByRole('link', { name: 'Go home' })).toBeVisible();
   });
 
@@ -44,7 +44,7 @@ test.describe('Navigation', () => {
     const breadcrumbs = page.locator('.breadcrumbs');
     await expect(breadcrumbs).toBeVisible();
     await expect(breadcrumbs.locator('a[href="/"]')).toHaveText('Home');
-    await expect(breadcrumbs.locator('a[href="/blog"]')).toHaveText('Blog');
+    await expect(breadcrumbs.locator('a[href="/blog"]')).toHaveText('Writing');
     await breadcrumbs.locator('a[href="/blog"]').click();
     await expect(page).toHaveURL('/blog');
   });
@@ -54,16 +54,16 @@ test.describe('Navigation', () => {
     await expect(page.locator('.breadcrumbs')).toHaveCount(0);
   });
 
-  test('profile avatar is visible in header', async ({ page }) => {
+  test('profile avatar is visible in the rail', async ({ page }) => {
     await page.goto('/');
-    await expect(page.locator('.profile-avatar')).toBeVisible();
+    await expect(page.locator('.rail-avatar')).toBeVisible();
   });
 
-  test('header is visible on all pages', async ({ page }) => {
+  test('sidebar rail is visible on all pages', async ({ page }) => {
     for (const path of ['/', '/blog', '/cv']) {
       await page.goto(path);
-      await expect(page.locator('header h1 a')).toBeVisible();
-      await expect(page.locator('nav')).toBeVisible();
+      await expect(page.locator('aside.app-sidebar')).toBeVisible();
+      await expect(page.locator('.rail-nav')).toBeVisible();
     }
   });
 });

--- a/tests/e2e/pwa.spec.ts
+++ b/tests/e2e/pwa.spec.ts
@@ -5,9 +5,9 @@ test.describe('PWA', () => {
     const response = await request.get('/manifest.webmanifest');
     expect(response.status()).toBe(200);
     const manifest = await response.json();
-    expect(manifest.name).toBe("Pete's Progressive Web App Portfolio");
-    expect(manifest.short_name).toBe("Pete's PWA");
-    expect(manifest.display).toBe('fullscreen');
+    expect(manifest.name).toBe('Pete Watters — Senior Web3 Frontend Engineer');
+    expect(manifest.short_name).toBe('Pete Watters');
+    expect(manifest.display).toBe('standalone');
     expect(manifest.icons).toHaveLength(2);
   });
 

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -4,7 +4,7 @@ const cases = [
   { slug: 'leather-mobile', title: 'Leather Mobile — Bitcoin Wallet on iOS and Android', company: 'Trust Machines' },
   { slug: 'leather-nfts',   title: 'Leather NFT Gallery — Two Chains, Multimedia, AI-Assisted Build', company: 'Trust Machines' },
   { slug: 'cryptowatch',    title: 'Cryptowatch Trading Surface — Real Money, Millions of Users', company: 'Kraken' },
-  { slug: 'coderunner',     title: "Coderunner — Kraken's Greenfield Trading Automation", company: 'Kraken' },
+  { slug: 'coderunner',     title: "Coderunner — Kraken's Trading Automation Tool", company: 'Kraken' },
   { slug: 'xapo',           title: 'Xapo', company: 'Xapo' },
   { slug: 'qredo',          title: 'Qredo', company: 'Qredo' },
 ];


### PR DESCRIPTION
## Summary
- Fix all 24 failing integration tests on the release PR — every one was a stale assertion, not a regression; spec drift accumulated because this suite never ran on PRs to `dev`
- `home.spec`: title is `Web3 Engineer | Pete Watters`; availability badge, nav, wordmark, headline, bio and shipped-at strip all live in the sidebar rail; 7 case-study cards including the external repo card
- `navigation.spec`: no `<header>` exists any more — rail avatar links home, rail is asserted on every page, socials live in the contact section with `target=_blank`; 404 heading is an `h1`
- `blog.spec`: listing title/breadcrumb say Writing; tag filter buttons use `aria-pressed`
- `cv.spec`: intro line is now "Engineer building for the web for nearly 20 years"
- `pwa.spec`: manifest name/short_name/display match `astro.config.mjs`
- `work.spec`: Coderunner title dropped "Greenfield" (#110)
- **`integration-tests.yml` now runs on PRs to `dev` as well as `main`** — spec drift surfaces on the PR that introduces it, not at release time

## Linked issue
Type: test + ci (unblocks the dev → main release PR)