### PR TITLE
ci: don't fail production deploys on missing alias URL

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -59,7 +59,7 @@ jobs:
             DEPLOY_OUTPUT=$(npx wrangler pages deploy dist --project-name=portfolio --commit-dirty=true 2>&1)
           fi
           echo "$DEPLOY_OUTPUT"
-          URL=$(echo "$DEPLOY_OUTPUT" | grep 'alias URL' | grep -oE 'https://[^ ]+')
+          URL=$(echo "$DEPLOY_OUTPUT" | grep 'alias URL' | grep -oE 'https://[^ ]+' || true)
           echo "url=$URL" >> "$GITHUB_OUTPUT"
       - name: Comment preview URL on PR
         if: github.event_name == 'pull_request' && steps.deploy.outputs.url


### PR DESCRIPTION
## Summary
- Every push-to-`main` deploy since at least mid-May has reported failure despite deploying successfully: the URL-extraction `grep 'alias URL'` finds nothing on production deploys (only branch deploys print an alias), exits 1, and `bash -e` fails the step after wrangler has already finished
- Tolerate the missing alias with `|| true` — PR/dev preview-URL extraction is unchanged

## Linked issue
Type: ci