### PR TITLE
fix(home): place PGP key inline with the contact line

### DIFF
--- a/src/components/ContactSection.astro
+++ b/src/components/ContactSection.astro
@@ -8,15 +8,17 @@ const EMAIL = 'hello@petewatters.ie';
 
 <section class="contact-section" id="contact" aria-labelledby="contact-label">
   <p class="section-label" id="contact-label">Contact</p>
-  <p class="contact-bio">
-    Contact me at <a href={`mailto:${EMAIL}`}>{EMAIL}</a>, or find me on
-    <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer">GitHub</a>,
-    <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer">X</a>,
-    or <a href={SOCIAL.LINKEDIN} target="_blank" rel="noopener noreferrer">LinkedIn</a>.
-  </p>
-  <div class="contact-pgp">
-    <span class="contact-pgp-label">PGP</span>
-    <a class="contact-pgp-key" href="/pgp.asc">030C 8DB6 C41D F87C 6EA1 964E C723 EA1A 8C81 132B</a>
+  <div class="contact-row">
+    <p class="contact-bio">
+      Contact me at <a href={`mailto:${EMAIL}`}>{EMAIL}</a>, or find me on
+      <a href={SOCIAL.GITHUB} target="_blank" rel="noopener noreferrer">GitHub</a>,
+      <a href={SOCIAL.X} target="_blank" rel="noopener noreferrer">X</a>,
+      or <a href={SOCIAL.LINKEDIN} target="_blank" rel="noopener noreferrer">LinkedIn</a>.
+    </p>
+    <div class="contact-pgp">
+      <span class="contact-pgp-label">PGP</span>
+      <a class="contact-pgp-key" href="/pgp.asc">030C 8DB6 C41D F87C 6EA1 964E C723 EA1A 8C81 132B</a>
+    </div>
   </div>
 </section>
 
@@ -25,6 +27,14 @@ const EMAIL = 'hello@petewatters.ie';
     --ease-hover: ease;
     text-align: left;
     margin-top: 2rem;
+  }
+
+  .contact-row {
+    display: flex;
+    align-items: baseline;
+    justify-content: space-between;
+    gap: 1rem 2rem;
+    flex-wrap: wrap;
   }
 
   .contact-bio {
@@ -48,11 +58,9 @@ const EMAIL = 'hello@petewatters.ie';
   }
 
   .contact-pgp {
-    margin-top: 1.5rem;
     display: flex;
     align-items: center;
     gap: 0.7rem;
-    flex-wrap: wrap;
   }
   .contact-pgp-label {
     font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- Contact sentence and PGP chip now share one baseline-aligned row (space-between, wraps on narrow screens) instead of the chip sitting on its own line below

## Linked issue
Type: fix (visual polish)