### PR TITLE
fix(work): center embedded images with proper caption styling

### DIFF
--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -260,11 +260,25 @@ const data = entry.data;
   .case-study-body :global(p:has(> img:only-child)) { text-align: center; }
   .case-study-body :global(p > img) {
     max-width: 100%;
-    max-height: 440px;
+    max-height: 640px;
     height: auto;
     border-radius: 0.5rem;
     border: 1px solid var(--color-border);
     display: inline-block;
+  }
+  .case-study-body :global(p:has(> img):has(> em)) {
+    text-align: center;
+    margin: 2.5rem 0;
+  }
+  .case-study-body :global(p:has(> img) > em) {
+    display: block;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-style: normal;
+    line-height: 1.5;
+    color: var(--color-faint);
+    max-width: 38em;
+    margin: 0.65rem auto 0;
   }
   .case-study-body :global(figcaption) {
     font-family: var(--font-mono);


### PR DESCRIPTION
## Summary
- Markdown image + `*caption*` pairs render in one paragraph; the caption previously flowed inline beside the image as plain italic body text
- Caption is now a block under the image: centered, mono, faint, width-capped — matching the existing `figcaption` treatment
- Embedded images can render up to 640px tall (was 440px) and stay centered

## Linked issue
Type: fix (visual polish)