### PR TITLE
feat(work): portfolio case study + GitHub repo links on cards and case studies

### DIFF
--- a/src/content/config.ts
+++ b/src/content/config.ts
@@ -32,6 +32,7 @@ const work = defineCollection({
     headline: z.string(),
     subtitle: z.string().optional(),
     confidentiality: z.string(),
+    repo: z.string().url().optional(),
     tech: z.array(z.string()),
     order: z.number(),
     outcomeText: z.string().optional(),

--- a/src/content/work/leather-mobile.md
+++ b/src/content/work/leather-mobile.md
@@ -8,6 +8,7 @@ stat: "1,850+ MAU within three months · launched at BTC Vegas 2025"
 headline: "Shipped Leather's first mobile app — zero to App Store in 3 months."
 subtitle: "Leather (formerly Hiro Wallet) is an open-source, self-custodial Bitcoin and Stacks wallet. Before this work it lived only as a browser extension; the mobile app was net-new."
 confidentiality: "This case study describes my personal contributions as a contractor at Trust Machines. The Leather wallet is open source — my work is publicly visible at github.com/leather-io. Technical details reflect my own experience and do not represent official Trust Machines communications."
+repo: "https://github.com/leather-io"
 tech:
   - React Native
   - Expo

--- a/src/content/work/leather-nfts.md
+++ b/src/content/work/leather-nfts.md
@@ -8,6 +8,7 @@ stat: "Stacks SIP-9 + Bitcoin Ordinals · video + audio playback · ~5,800-line 
 headline: "A multi-chain NFT gallery for a Bitcoin wallet."
 subtitle: "Two very different on-chain data models — Stacks SIP-9 and Bitcoin Ordinals — collapsed into a single coherent gallery UI, shared across the Leather extension and mobile app."
 confidentiality: "This case study describes my personal contributions as a contractor at Trust Machines. The Leather wallet is open source — my work is publicly visible at github.com/leather-io. Technical details reflect my own experience and do not represent official Trust Machines communications."
+repo: "https://github.com/leather-io"
 tech:
   - TypeScript
   - React

--- a/src/content/work/portfolio-pwa.md
+++ b/src/content/work/portfolio-pwa.md
@@ -1,0 +1,69 @@
+---
+title: "petewatters.ie — An Astro PWA With Build-Time On-Chain Data"
+company: "Independent"
+project: "petewatters.ie"
+role: "Designer & Engineer"
+period: "2026"
+headline: "This site — an Astro PWA with build-time on-chain data."
+subtitle: "The portfolio you're reading: static-rendered, offline-capable, and personal — a live GitHub contribution graph and a Solana-NFT avatar fetched at build time, so what you see is real and current at zero runtime cost."
+confidentiality: "petewatters.ie is my own independent project — all architecture, code, design, and content are my own work. The code is open source under AGPL-3.0; the writing, imagery, and identity are reserved."
+repo: "https://github.com/pete-watters/portfolio-pwa"
+tech:
+  - Astro 5
+  - TypeScript
+  - PWA / Workbox
+  - Pagefind
+  - Playwright
+  - playwright-bdd
+  - Vale
+  - Cloudflare Pages
+  - GitHub Actions
+  - Helius API
+order: 7
+outcomeStats:
+  - number: "0"
+    label: "Runtime API calls — every piece of live data is baked in at build time"
+  - number: "3"
+    label: "Deploy targets — production, staging, and an ephemeral preview per PR"
+  - number: "249"
+    label: "Functional browser checks across Chromium, Firefox and WebKit"
+draft: false
+---
+
+## Overview
+
+A portfolio site is a strange product: it has one user who matters at a time, it gets judged in under a minute, and — for an engineer — it *is* the work sample. So this site is built the way I build products: static-first for speed, a real test suite, a real release process, and a couple of genuinely unusual tricks where they earn their place.
+
+The stack is deliberately boring where boring is right — Astro 5, plain CSS, TypeScript strict — and interesting where it counts.
+
+## Build-time on-chain data
+
+The two "live" elements on the homepage are fetched at **build time**, not in the browser:
+
+- **The avatar is a Solana NFT.** At build, the site resolves the NFT's current image via the Helius API and bakes it into the page. Change the NFT, redeploy, new avatar — no client-side wallet calls, no loading spinner.
+- **The open-source section is a live GitHub contribution graph**, queried from the GitHub API during the build, so it's always current as of the latest deploy.
+
+The effect is data that is *real* — verifiable on-chain, verifiable on GitHub — with the runtime cost of a static page: zero API calls, nothing to rate-limit, nothing to fall over.
+
+## An installable, offline-capable PWA
+
+The site ships as a progressive web app — Workbox service worker, install manifest, offline fallback — so it loads instantly on repeat visits and survives a dead connection. Search is **Pagefind**, indexed at build over the blog and case studies, served as static chunks: full-text search with no search server.
+
+## Tested like a product
+
+The quality gates are the same shape I set up for client work:
+
+- **Functional end-to-end suite** — Playwright across Chromium, Firefox and WebKit, run on every pull request.
+- **Visual regression guardrail** — a playwright-bdd suite screenshots every primary route against committed baselines, so a styling regression or a blank page fails CI instead of reaching production.
+- **Prose linting** — Vale runs over every blog post before publication.
+- Lint, strict type-checking, and unit tests on every change.
+
+## Shipped like a product
+
+GitFlow with a protected production branch: features PR into `dev` (staging), and a release is a single `dev → main` promotion that tags a version, publishes release notes, and deploys — one click, end to end. Cloudflare Pages serves production, a staging environment, and an ephemeral preview per pull request.
+
+The code is open source under **AGPL-3.0** — the engineering is there to read, which is the point of a portfolio. The content, writing, and identity stay mine.
+
+## Outcome
+
+A fast, installable, offline-capable site where the interesting claims — the on-chain avatar, the live contribution graph, the test discipline — are verifiable rather than asserted. The repo is the case study.

--- a/src/content/work/simplyfpl.md
+++ b/src/content/work/simplyfpl.md
@@ -8,6 +8,7 @@ stat: "One-person company: real-time, edge-served, crash-proof — built by dire
 headline: "A real-time Fantasy Premier League product, built solo."
 subtitle: "SimplyFPL is a faster, calmer, never-crashes alternative to the incumbent live-rank trackers. Edge-served from Cloudflare, tested like a team product, and built by steering AI across architecture, infra, design, and ops — with me reviewing and signing off every commit."
 confidentiality: "SimplyFPL is my own independent product. All architecture decisions, code, screenshots, and technical details here are my own work."
+repo: "https://github.com/pete-watters/simply-fpl"
 tech:
   - Next.js 15
   - TypeScript

--- a/src/content/work/stackr.md
+++ b/src/content/work/stackr.md
@@ -8,6 +8,7 @@ stat: "4 chains · Bitcoin · Ethereum · Solana · Stacks — wallet-connect + 
 headline: "A self-custodial cross-chain portfolio terminal."
 subtitle: "Stackr tracks balances, allocation, and activity across Bitcoin, Ethereum, Solana, and Stacks in one view — computed entirely client-side from public chain RPCs."
 confidentiality: "Stackr is my own product — built in the open on a public repo, but proprietary (all rights reserved). All figures and addresses shown here are mock data."
+repo: "https://github.com/pete-watters/stackr"
 tech:
   - Next.js 15
   - React 19

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,9 +39,14 @@ import ContactSection from '../components/ContactSection.astro';
             <li>Design System</li>
             <li>AI Tooling</li>
           </ul>
-          <a class="case-card-link" href="/work/leather-mobile/">
-            View case study <span class="arrow" aria-hidden="true">→</span>
-          </a>
+          <div class="case-card-links">
+            <a class="case-card-link" href="/work/leather-mobile/">
+              View case study <span class="arrow" aria-hidden="true">→</span>
+            </a>
+            <a class="case-card-repo" href="https://github.com/leather-io" target="_blank" rel="noopener noreferrer">
+              GitHub <span class="arrow" aria-hidden="true">↗</span>
+            </a>
+          </div>
         </div>
       </article>
 
@@ -181,9 +186,14 @@ import ContactSection from '../components/ContactSection.astro';
               <li>Cloudflare</li>
               <li>Design</li>
             </ul>
-            <a class="case-card-link" href="/work/stackr/">
-              View project <span class="arrow" aria-hidden="true">→</span>
-            </a>
+            <div class="case-card-links">
+              <a class="case-card-link" href="/work/stackr/">
+                View project <span class="arrow" aria-hidden="true">→</span>
+              </a>
+              <a class="case-card-repo" href="https://github.com/pete-watters/stackr" target="_blank" rel="noopener noreferrer">
+                GitHub <span class="arrow" aria-hidden="true">↗</span>
+              </a>
+            </div>
           </div>
         </article>
 
@@ -208,9 +218,14 @@ import ContactSection from '../components/ContactSection.astro';
               <li>Real-time</li>
               <li>AI workflow</li>
             </ul>
-            <a class="case-card-link" href="/work/simplyfpl/">
-              View project <span class="arrow" aria-hidden="true">→</span>
-            </a>
+            <div class="case-card-links">
+              <a class="case-card-link" href="/work/simplyfpl/">
+                View project <span class="arrow" aria-hidden="true">→</span>
+              </a>
+              <a class="case-card-repo" href="https://github.com/pete-watters/simply-fpl" target="_blank" rel="noopener noreferrer">
+                GitHub <span class="arrow" aria-hidden="true">↗</span>
+              </a>
+            </div>
           </div>
         </article>
 
@@ -235,9 +250,14 @@ import ContactSection from '../components/ContactSection.astro';
               <li>TypeScript</li>
               <li>Cloudflare</li>
             </ul>
-            <a class="case-card-link" href="https://github.com/pete-watters/portfolio-pwa" target="_blank" rel="noopener noreferrer">
-              View source <span class="arrow" aria-hidden="true">→</span>
-            </a>
+            <div class="case-card-links">
+              <a class="case-card-link" href="/work/portfolio-pwa/">
+                View case study <span class="arrow" aria-hidden="true">→</span>
+              </a>
+              <a class="case-card-repo" href="https://github.com/pete-watters/portfolio-pwa" target="_blank" rel="noopener noreferrer">
+                GitHub <span class="arrow" aria-hidden="true">↗</span>
+              </a>
+            </div>
           </div>
         </article>
       </div>
@@ -847,6 +867,30 @@ import ContactSection from '../components/ContactSection.astro';
     transition: transform 0.3s var(--ease-out-soft);
   }
   .case-card-link:hover .arrow { transform: translateX(4px); }
+
+  .case-card-links {
+    display: flex;
+    align-items: baseline;
+    gap: 1.75rem;
+  }
+  .case-card-repo {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-muted);
+    text-decoration: none;
+    border-bottom: 1px solid transparent;
+    padding-bottom: 1px;
+    transition: color 0.25s var(--ease-out-soft), border-color 0.25s var(--ease-out-soft);
+  }
+  .case-card-repo:hover {
+    color: var(--color-text);
+    border-bottom-color: var(--color-text);
+  }
+  .case-card-repo .arrow {
+    display: inline-block;
+    transition: transform 0.3s var(--ease-out-soft);
+  }
+  .case-card-repo:hover .arrow { transform: translate(2px, -2px); }
 
   /* TIMELINE */
   .timeline .section-label { margin-bottom: 1.5rem; }

--- a/src/pages/work/[slug].astro
+++ b/src/pages/work/[slug].astro
@@ -40,6 +40,12 @@ const data = entry.data;
       {data.stat && <p class="case-study-stat">{data.stat}</p>}
       <h1 class="case-study-headline">{data.headline}</h1>
       {data.subtitle && <p class="case-study-subtitle">{data.subtitle}</p>}
+      {data.repo && (
+        <a class="case-study-repo" href={data.repo} target="_blank" rel="noopener noreferrer">
+          <svg viewBox="0 0 16 16" width="16" height="16" aria-hidden="true" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82a7.42 7.42 0 0 1 2-.27c.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0 0 16 8c0-4.42-3.58-8-8-8Z"/></svg>
+          View source on GitHub <span class="arrow" aria-hidden="true">↗</span>
+        </a>
+      )}
     </header>
 
     <aside class="case-study-notice">
@@ -163,6 +169,31 @@ const data = entry.data;
     margin: 0;
     max-width: 38em;
   }
+
+  .case-study-repo {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    margin-top: 1.5rem;
+    font-family: var(--font-mono);
+    font-size: 13px;
+    color: var(--color-text);
+    text-decoration: none;
+    padding: 0.55rem 1rem;
+    border: 1px solid var(--color-border);
+    border-radius: 0.45rem;
+    transition: border-color 0.25s var(--ease-out-soft), color 0.25s var(--ease-out-soft), background-color 0.25s var(--ease-out-soft);
+  }
+  .case-study-repo:hover {
+    border-color: var(--color-accent);
+    color: var(--color-accent);
+    background: rgba(247, 147, 26, 0.05);
+  }
+  .case-study-repo .arrow {
+    display: inline-block;
+    transition: transform 0.3s var(--ease-out-soft);
+  }
+  .case-study-repo:hover .arrow { transform: translate(2px, -2px); }
 
   /* CONFIDENTIALITY NOTICE */
   .case-study-notice {

--- a/tests/e2e/home.spec.ts
+++ b/tests/e2e/home.spec.ts
@@ -64,7 +64,7 @@ test.describe('Home page', () => {
     await expect(page.locator('.case-card')).toHaveCount(7);
   });
 
-  test('case study cards link to /work/<slug>/ plus the repo', async ({ page }) => {
+  test('every case study card links to its /work/<slug>/ page', async ({ page }) => {
     await page.goto('/');
     const links = page.locator('.case-card-link');
     await expect(links).toHaveCount(7);
@@ -74,8 +74,21 @@ test.describe('Home page', () => {
     await expect(links.nth(3)).toHaveAttribute('href', '/work/qredo/');
     await expect(links.nth(4)).toHaveAttribute('href', '/work/stackr/');
     await expect(links.nth(5)).toHaveAttribute('href', '/work/simplyfpl/');
-    await expect(links.nth(6)).toHaveAttribute('href', 'https://github.com/pete-watters/portfolio-pwa');
-    await expect(links.nth(6)).toHaveAttribute('target', '_blank');
+    await expect(links.nth(6)).toHaveAttribute('href', '/work/portfolio-pwa/');
+  });
+
+  test('open-source project cards show GitHub repo links opening in new tabs', async ({ page }) => {
+    await page.goto('/');
+    const repoLinks = page.locator('.case-card-repo');
+    await expect(repoLinks).toHaveCount(4);
+    await expect(repoLinks.nth(0)).toHaveAttribute('href', 'https://github.com/leather-io');
+    await expect(repoLinks.nth(1)).toHaveAttribute('href', 'https://github.com/pete-watters/stackr');
+    await expect(repoLinks.nth(2)).toHaveAttribute('href', 'https://github.com/pete-watters/simply-fpl');
+    await expect(repoLinks.nth(3)).toHaveAttribute('href', 'https://github.com/pete-watters/portfolio-pwa');
+    for (const link of await repoLinks.all()) {
+      await expect(link).toHaveAttribute('target', '_blank');
+      await expect(link).toHaveAttribute('rel', 'noopener noreferrer');
+    }
   });
 
   test('timeline lists every role from Trust Machines back to Earlier', async ({ page }) => {

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -7,7 +7,16 @@ const cases = [
   { slug: 'coderunner',     title: "Coderunner — Kraken's Trading Automation Tool", company: 'Kraken' },
   { slug: 'xapo',           title: 'Xapo', company: 'Xapo' },
   { slug: 'qredo',          title: 'Qredo', company: 'Qredo' },
+  { slug: 'portfolio-pwa',  title: 'petewatters.ie — An Astro PWA With Build-Time On-Chain Data', company: 'Independent' },
 ];
+
+const reposBySlug = {
+  'leather-mobile': 'https://github.com/leather-io',
+  'leather-nfts': 'https://github.com/leather-io',
+  'stackr': 'https://github.com/pete-watters/stackr',
+  'simplyfpl': 'https://github.com/pete-watters/simply-fpl',
+  'portfolio-pwa': 'https://github.com/pete-watters/portfolio-pwa',
+};
 
 test.describe('Case study pages', () => {
   for (const { slug, title, company } of cases) {
@@ -61,6 +70,24 @@ test.describe('Case study pages', () => {
       await page.goto(`/work/${slug}/`);
       await expect(page.locator('.outcome-text')).toBeVisible();
       await expect(page.locator('.outcome-grid')).toHaveCount(0);
+    }
+  });
+
+  test('open-source case studies show a prominent source link in the hero', async ({ page }) => {
+    for (const [slug, repo] of Object.entries(reposBySlug)) {
+      await page.goto(`/work/${slug}/`);
+      const repoLink = page.locator('.case-study-repo');
+      await expect(repoLink).toBeVisible();
+      await expect(repoLink).toHaveAttribute('href', repo);
+      await expect(repoLink).toHaveAttribute('target', '_blank');
+      await expect(repoLink).toHaveAttribute('rel', 'noopener noreferrer');
+    }
+  });
+
+  test('proprietary case studies have no source link', async ({ page }) => {
+    for (const slug of ['cryptowatch', 'coderunner', 'xapo', 'qredo']) {
+      await page.goto(`/work/${slug}/`);
+      await expect(page.locator('.case-study-repo')).toHaveCount(0);
     }
   });
 

--- a/tests/e2e/work.spec.ts
+++ b/tests/e2e/work.spec.ts
@@ -73,23 +73,23 @@ test.describe('Case study pages', () => {
     }
   });
 
-  test('open-source case studies show a prominent source link in the hero', async ({ page }) => {
-    for (const [slug, repo] of Object.entries(reposBySlug)) {
+  for (const [slug, repo] of Object.entries(reposBySlug)) {
+    test(`/work/${slug} shows a prominent source link in the hero`, async ({ page }) => {
       await page.goto(`/work/${slug}/`);
       const repoLink = page.locator('.case-study-repo');
       await expect(repoLink).toBeVisible();
       await expect(repoLink).toHaveAttribute('href', repo);
       await expect(repoLink).toHaveAttribute('target', '_blank');
       await expect(repoLink).toHaveAttribute('rel', 'noopener noreferrer');
-    }
-  });
+    });
+  }
 
-  test('proprietary case studies have no source link', async ({ page }) => {
-    for (const slug of ['cryptowatch', 'coderunner', 'xapo', 'qredo']) {
+  for (const slug of ['cryptowatch', 'coderunner', 'xapo', 'qredo']) {
+    test(`/work/${slug} has no source link`, async ({ page }) => {
       await page.goto(`/work/${slug}/`);
       await expect(page.locator('.case-study-repo')).toHaveCount(0);
-    }
-  });
+    });
+  }
 
   test('Old /work/leather redirects to /work/leather-mobile', async ({ page }) => {
     await page.goto('/work/leather');


### PR DESCRIPTION
## Summary
- New case study at `/work/portfolio-pwa/` for this site (build-time on-chain data, PWA, test/release discipline); the home card now links to it instead of straight to the repo
- New optional `repo` field in the work collection schema; set on the five projects with public code (Leather ×2 → `leather-io`, Stackr, SimplyFPL, this site)
- Case-study hero renders a prominent "View source on GitHub" button (new tab) when `repo` is set; proprietary studies (Cryptowatch, Coderunner, Xapo, Qredo) are unchanged
- Home cards for open-source projects get a secondary "GitHub ↗" link beside the case-study link, opening in a new tab
- e2e: +8 assertions covering card hrefs, repo links on home, hero source links, and the no-repo guarantee on proprietary studies

## Linked issue
Type: feat