### PR TITLE
feat(home): timeline variant 1 — dark ledger panel

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -249,6 +249,7 @@ import ContactSection from '../components/ContactSection.astro';
       <p class="section-label">Resume 2014 → 2026</p>
       <ol class="timeline-rows">
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#09</span>
           <div class="timeline-company">Trust Machines</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Senior Frontend Engineer</span>
@@ -257,6 +258,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Jul 2023 — Present</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#08</span>
           <div class="timeline-company">Qredo</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Senior Frontend Engineer</span>
@@ -265,6 +267,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Jan — Jun 2023</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#07</span>
           <div class="timeline-company">Kraken</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Senior Frontend Engineer</span>
@@ -273,6 +276,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Aug 2020 — Nov 2022</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#06</span>
           <div class="timeline-company">Xapo</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Senior Frontend Engineer</span>
@@ -281,6 +285,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Nov 2017 — Apr 2020</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#05</span>
           <div class="timeline-company">Bank of America</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Senior Frontend Engineer</span>
@@ -289,6 +294,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">May — Oct 2017</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#04</span>
           <div class="timeline-company">Rocksteady</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Lead JavaScript Developer</span>
@@ -297,6 +303,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Apr 2016 — Mar 2017</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#03</span>
           <div class="timeline-company">Kontainers</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Full-Stack Developer</span>
@@ -305,6 +312,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Jun 2015 — Apr 2016</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#02</span>
           <div class="timeline-company">Fidelity</div>
           <div class="timeline-role">
             <span class="timeline-role-name">UX Developer</span>
@@ -313,6 +321,7 @@ import ContactSection from '../components/ContactSection.astro';
           <div class="timeline-period">Jun 2014 — Jun 2015</div>
         </li>
         <li class="timeline-row" data-reveal>
+          <span class="timeline-index" aria-hidden="true">#01</span>
           <div class="timeline-company">Earlier</div>
           <div class="timeline-role">
             <span class="timeline-role-name">Yahoo! · eSpatial · The Now Factory · IBM · HP</span>
@@ -853,81 +862,76 @@ import ContactSection from '../components/ContactSection.astro';
 
   .timeline-rows {
     list-style: none;
-    padding: 0;
+    padding: 0.35rem 0;
     margin: 0;
-    border-top: 1px solid var(--color-border);
+    background: var(--color-dark);
+    border: 1px solid rgba(255, 255, 255, 0.07);
+    border-radius: 0.75rem;
+    overflow: hidden;
   }
 
   .timeline-row {
     position: relative;
     display: grid;
-    grid-template-columns: 1.4fr 2.6fr 1.2fr;
-    gap: 1.5rem;
-    padding: 1.1rem 0 1.1rem 1.9rem;
-    border-bottom: 1px solid var(--color-border);
+    grid-template-columns: 2.4rem 1.3fr 2.7fr auto;
+    gap: 1.25rem;
+    padding: 1.05rem 1.4rem;
+    border-bottom: 1px solid rgba(255, 255, 255, 0.05);
     align-items: baseline;
   }
+  .timeline-row:last-child { border-bottom: none; }
+  .timeline-row:hover { background: rgba(255, 255, 255, 0.035); }
 
   .timeline-row::before {
     content: '';
     position: absolute;
-    left: 5px;
+    left: 0;
     top: 0;
     bottom: 0;
     width: 2px;
-    background: var(--color-border);
-    transform: scaleY(1);
-    transform-origin: top;
-    transition: transform 0.55s var(--ease-out-soft);
-  }
-  .timeline-row::after {
-    content: '';
-    position: absolute;
-    left: 0.5px;
-    top: 1.55rem;
-    width: 11px;
-    height: 11px;
-    border-radius: 50%;
     background: var(--color-accent);
-    box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.12);
-    transform: scale(1);
-    transition: transform 0.45s var(--ease-out-soft) 0.1s;
+    transform: scaleY(0);
+    transform-origin: bottom;
+    transition: transform 0.3s var(--ease-out-soft);
   }
-  .js .timeline-row::before { transform: scaleY(0); }
-  .js .timeline-row::after { transform: scale(0); }
-  .timeline-row.is-visible::before { transform: scaleY(1); }
-  .timeline-row.is-visible::after { transform: scale(1); }
-  @media (prefers-reduced-motion: reduce) {
-    .timeline-row::before { transform: scaleY(1); transition: none; }
-    .timeline-row::after { transform: scale(1); transition: none; }
+  .timeline-row:hover::before { transform: scaleY(1); }
+
+  .timeline-index {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.3);
+    transition: color 0.25s var(--ease-out-soft);
   }
+  .timeline-row:hover .timeline-index { color: var(--color-accent); }
 
   .timeline-company {
     font-weight: 600;
-    color: var(--color-text);
+    color: #fff;
   }
 
   .timeline-role {
     display: flex;
     flex-direction: column;
-    gap: 0.2rem;
+    gap: 0.25rem;
   }
 
   .timeline-role-name {
-    color: var(--color-text);
-    font-size: 0.95rem;
+    color: rgba(255, 255, 255, 0.85);
+    font-size: 0.92rem;
   }
 
   .timeline-role-blurb {
-    color: var(--color-muted);
-    font-size: 0.9rem;
-    line-height: 1.5;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: rgba(255, 255, 255, 0.42);
+    line-height: 1.6;
   }
 
   .timeline-period {
     font-family: var(--font-mono);
-    font-size: 13px;
-    color: var(--color-faint);
+    font-size: 12px;
+    color: var(--color-accent);
+    opacity: 0.9;
     text-align: right;
     white-space: nowrap;
   }
@@ -943,10 +947,12 @@ import ContactSection from '../components/ContactSection.astro';
     .case-card-visual { aspect-ratio: 16 / 10; }
 
     .timeline-row {
-      grid-template-columns: 1fr;
-      gap: 0.25rem;
-      padding: 1rem 0 1rem 1.9rem;
+      grid-template-columns: 2.4rem 1fr;
+      gap: 0.25rem 1.1rem;
+      padding: 1rem 1.25rem;
     }
+    .timeline-role,
+    .timeline-period { grid-column: 2; }
     .timeline-period { text-align: left; }
   }
 


### PR DESCRIPTION
## Summary
- Timeline redesign **option 1 of 3** — pick one, close the others
- Dark terminal-style panel (matches the Cryptowatch mock / dark header): mono `#09…#01` indices, white company names, mono blurbs, orange periods; hovering a row sweeps an orange rail up its left edge

## Linked issue
Type: feat (design variant — preview PR)