### PR TITLE
feat(home): join timeline rows into one continuous rail

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -873,7 +873,7 @@ import ContactSection from '../components/ContactSection.astro';
     top: -2px;
     bottom: -2px;
     width: 2px;
-    background: var(--color-border);
+    background: #d6d6d6;
     transform: scaleY(1);
     transform-origin: top;
     transition: transform 0.55s var(--ease-out-soft);
@@ -883,18 +883,17 @@ import ContactSection from '../components/ContactSection.astro';
   .timeline-row::after {
     content: '';
     position: absolute;
-    left: 0.5px;
-    top: 1.45rem;
-    width: 11px;
-    height: 11px;
+    left: 1.5px;
+    top: 1.5rem;
+    width: 9px;
+    height: 9px;
     border-radius: 50%;
     background: var(--color-accent);
-    box-shadow: 0 0 0 3px #fff, 0 0 0 4px rgba(247, 147, 26, 0.35);
     transform: scale(1);
     transition: transform 0.45s var(--ease-out-soft) 0.1s, box-shadow 0.3s var(--ease-out-soft);
   }
   .timeline-row:hover::after {
-    box-shadow: 0 0 0 3px #fff, 0 0 0 5px rgba(247, 147, 26, 0.7);
+    box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.18);
   }
   .js .timeline-row::before { transform: scaleY(0); }
   .js .timeline-row::after { transform: scale(0); }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -855,7 +855,6 @@ import ContactSection from '../components/ContactSection.astro';
     list-style: none;
     padding: 0;
     margin: 0;
-    border-top: 1px solid var(--color-border);
   }
 
   .timeline-row {
@@ -863,8 +862,7 @@ import ContactSection from '../components/ContactSection.astro';
     display: grid;
     grid-template-columns: 1.4fr 2.6fr 1.2fr;
     gap: 1.5rem;
-    padding: 1.1rem 0 1.1rem 1.9rem;
-    border-bottom: 1px solid var(--color-border);
+    padding: 1rem 0 1rem 1.9rem;
     align-items: baseline;
   }
 
@@ -872,26 +870,31 @@ import ContactSection from '../components/ContactSection.astro';
     content: '';
     position: absolute;
     left: 5px;
-    top: 0;
-    bottom: 0;
+    top: -2px;
+    bottom: -2px;
     width: 2px;
     background: var(--color-border);
     transform: scaleY(1);
     transform-origin: top;
     transition: transform 0.55s var(--ease-out-soft);
   }
+  .timeline-row:first-child::before { top: 1.45rem; }
+  .timeline-row:last-child::before { bottom: calc(100% - 1.6rem); }
   .timeline-row::after {
     content: '';
     position: absolute;
     left: 0.5px;
-    top: 1.55rem;
+    top: 1.45rem;
     width: 11px;
     height: 11px;
     border-radius: 50%;
     background: var(--color-accent);
-    box-shadow: 0 0 0 4px rgba(247, 147, 26, 0.12);
+    box-shadow: 0 0 0 3px #fff, 0 0 0 4px rgba(247, 147, 26, 0.35);
     transform: scale(1);
-    transition: transform 0.45s var(--ease-out-soft) 0.1s;
+    transition: transform 0.45s var(--ease-out-soft) 0.1s, box-shadow 0.3s var(--ease-out-soft);
+  }
+  .timeline-row:hover::after {
+    box-shadow: 0 0 0 3px #fff, 0 0 0 5px rgba(247, 147, 26, 0.7);
   }
   .js .timeline-row::before { transform: scaleY(0); }
   .js .timeline-row::after { transform: scale(0); }


### PR DESCRIPTION
## Summary
- Keep the existing timeline design, fix the joins: per-row rail segments now overlap row boundaries so the line is continuous; the full-width row dividers (which chopped the rail at every boundary) are gone
- Rail starts at the first dot and ends at the last dot — no stubs above Trust Machines or below Earlier
- Dots get a white ring so they sit on the rail as nodes; row hover warms the dot's halo
- Rows tightened slightly (no divider + reduced padding) so the column reads as one connected spine
- Scroll draw-in animation unchanged

## Linked issue
Type: feat (visual polish)