### PR TITLE
chore(blog): Maestro, Expo and mobile-CI drafts from Leather

### DIFF
--- a/src/content/blog/expo-at-leather.md
+++ b/src/content/blog/expo-at-leather.md
@@ -1,0 +1,57 @@
+---
+title: "Building a Crypto Wallet on Expo"
+description: "What Expo and EAS gave a small team building a self-custody Bitcoin and Stacks wallet — the stack, the architecture, and the parts that punched above their weight."
+pubDate: 2026-06-15
+tags: ["expo", "mobile", "react-native", "leather"]
+draft: true
+---
+
+Most of my deep-dive posts pick one problem and chase it to the bottom. This one zooms out. I want to lay out what building [Leather](https://leather.io/)'s mobile wallet on [Expo](https://expo.dev/) actually looked like — the full stack a self-custody Bitcoin and Stacks wallet needed, and where the platform earned its keep for a small team.
+
+This is a point-in-time account of the setup we ran while I was on the project. Some of it has since changed; the engineering held up regardless.
+
+## The shape of the app
+
+Leather mobile was an Expo app on SDK 54, React Native 0.81, with file-based routing via [expo-router](https://docs.expo.dev/router/introduction/). We used the prebuild model — Expo generates and owns the native projects, and we layered config plugins on top rather than hand-editing Xcode and Gradle. That kept the native surface declarative: the app config was the source of truth, and `expo prebuild` produced the platforms from it.
+
+The dependency list told the real story. The app pulled in 34 `expo-*` packages, and they weren't padding — each one replaced something we'd otherwise have written and maintained natively:
+
+| Need | Expo module |
+|---|---|
+| Encrypted key storage | `expo-secure-store` |
+| Face ID / Touch ID | `expo-local-authentication` |
+| QR scanning for addresses | `expo-camera` |
+| Custom fonts | `expo-font` |
+| Crypto primitives | `expo-crypto`, `expo-standard-web-crypto` |
+| Switchable app icons | `expo-alternate-app-icons` |
+| Custom dev builds | `expo-dev-client` |
+
+A wallet lives or dies on the security-sensitive paths, and Expo had first-party modules for the two that mattered most — encrypted storage and biometrics. I wrote those up separately in [Secure Storage and Biometrics](/blog/expo-secure-storage-biometrics), because the details are worth their own post. The point here is that we got them as audited, maintained dependencies rather than bespoke native code.
+
+## The custom dev client
+
+We didn't use Expo Go. A wallet needs native modules Expo Go can't include, so we built our own development client with `expo-dev-client`. That gave us the iteration speed of Expo Go — push JavaScript, see it instantly — with the freedom to ship whatever native dependencies the app required. It's the setup I'd reach for on any non-trivial Expo app now: the convenience without the ceiling.
+
+## EAS as a force-multiplier
+
+Where Expo went from "nice SDK" to "this changes how a small team ships" was EAS. We used the three services together:
+
+- **EAS Build** for cloud builds across both platforms, so nobody needed a perfectly configured local Xcode to cut a build.
+- **EAS Update** for over-the-air JavaScript updates — most fixes shipped without an app-store round trip. I covered the financial-app considerations in [OTA Updates](/blog/expo-ota-updates).
+- **EAS Workflows** to orchestrate CI, including Maestro E2E tests against real builds.
+
+The hinge was fingerprinting. EAS hashes the inputs that affect the native runtime, so it knows when a PR is JavaScript-only and can reuse an existing native build. That single idea took our CI from twenty-minute builds to a fast path most PRs could take — the full story is in [How We Cut Our Mobile CI Time by 70%](/blog/expo-cicd-fingerprinting), with the testing machinery in [Part 2](/blog/maestro-eas-e2e-deep-dive).
+
+## Fitting into a monorepo
+
+Leather isn't a standalone app — it's a [Turborepo and pnpm workspace](/blog/designing-a-monorepo) where a browser extension and the mobile app share a couple of dozen packages. The interesting question was whether Expo would cooperate with that.
+
+It did, with two pieces of glue. The app consumed shared packages through the `workspace:*` protocol — `@leather.io/ui/native`, the bitcoin and stacks logic, queries, state — as ordinary dependencies. And Metro was pointed at the workspace root so it watched and resolved across the whole monorepo, not just the app's own folder. Once those were in place, a change to a shared UI component showed up in the running app with fast refresh, exactly as it would in a single-package project. Sharing a [cross-platform UI library](/blog/cross-platform-ui-library) between an extension and a native app is hard enough; Expo not getting in the way of it was worth a lot.
+
+## What it bought us
+
+The throughline is how much a small team got for how little it had to build. We shipped a production wallet — encrypted storage, biometrics, QR scanning, 11 switchable app icons, OTA updates, E2E tests on real devices in CI — without standing up most of the native infrastructure those features usually demand. Expo's modules covered the sensitive paths, the dev client kept iteration fast, EAS turned builds and updates into a pipeline, and none of it fought the monorepo. That's the case for Expo I'd make to anyone building something serious on React Native.
+
+---
+
+*This post lives on [petewatters.ie](https://petewatters.ie). If the Expo team would like a version for their blog, I'm happy to adapt it.*

--- a/src/content/blog/expo-cicd-fingerprinting.md
+++ b/src/content/blog/expo-cicd-fingerprinting.md
@@ -8,6 +8,8 @@ draft: false
 
 *This is Part 1 of the "Building a Crypto Wallet with Expo" series.*
 
+> This post reflects Leather's mobile CI as it stood in mid-2025. The setup has since evolved — treat it as a point-in-time account rather than the current state.
+
 Before joining the Leather mobile project, I'd never touched React Native, Expo or EAS. My CI experience was entirely web-focused -- GitHub Actions running lint, type checks and Playwright tests for the browser extension. Mobile CI was a different beast entirely. You're not just building JavaScript; you're compiling native binaries for two platforms, managing signing certificates, provisioning profiles and dealing with build times that make webpack look instant.
 
 I approached EAS the way I approach most new tooling: read the docs cover to cover, then start breaking things. The Expo documentation is genuinely excellent, and the EAS Workflows feature was still relatively new when we adopted it. I spent the first week just running builds locally, understanding what the different profiles did and getting a feel for what changed the native fingerprint versus what didn't. That investment paid off enormously -- once I understood the fingerprint concept, our entire CI strategy clicked into place.

--- a/src/content/blog/maestro-eas-e2e-deep-dive.md
+++ b/src/content/blog/maestro-eas-e2e-deep-dive.md
@@ -1,0 +1,126 @@
+---
+title: "Maestro and EAS, Part 2: The CI Machine Around the Tests"
+description: "A closer look at why Maestro's YAML model is a pleasure to work in, and the EAS Workflows build matrix — cached vs fresh, smoke-as-gate — I wrapped around it."
+pubDate: 2026-06-15
+tags: ["expo", "mobile", "ci", "testing", "leather"]
+draft: true
+---
+
+In [Part 1](/blog/expo-cicd-fingerprinting) I wrote that setting up Maestro was one of those rare cases where the tooling just works. That's still true, but it undersells the part that took the actual effort: the CI machine around the tests. This is the deeper cut — why Maestro itself is pleasant to work in, and how I structured the EAS Workflows pipeline that ran it.
+
+This is a point-in-time account. It describes the suite as I built it at Leather, on the EAS-based pipeline we used at the time.
+
+## Why Maestro's model holds up
+
+Maestro tests are YAML. That sounds like a limitation and turns out to be a feature. A flow is a flat list of commands against the running app, and that flatness makes flows readable by people who don't write the tests:
+
+```yaml
+appId: io.leather.mobilewallet
+---
+- tapOn:
+    id: 'homeCreateWalletCard'
+- tapOn: 'Create new wallet'
+- tapOn:
+    id: 'walletCreationTapToReveal'
+- tapOn:
+    id: 'walletCreationBackedUpButton'
+- tapOn: 'Skip for now'
+- tapOn: 'Continue'
+- extendedWaitUntil:
+    visible:
+      id: 'homePrivacyButton'
+    timeout: 10000
+```
+
+The two features I leaned on hardest were `runFlow` and conditionals. `runFlow` lets flows compose, so setup steps live in one place and get reused — wallet creation, cleanup, removal are each a shared subflow that the bigger journeys pull in:
+
+```yaml
+- runFlow: ../shared/create-wallet-dev-console.yaml
+# ...later...
+- runFlow: ../shared/remove-wallet.yaml
+```
+
+Conditionals handle the things real apps throw at you mid-flow — a passcode prompt, an OS dialog, a deep-link confirmation that only iOS shows:
+
+```yaml
+- runFlow:
+    when:
+      visible: 'Open'
+    commands:
+      - tapOn: 'Open'
+```
+
+And `extendedWaitUntil` replaces the sleep-and-pray pattern with an explicit condition and timeout. After a JS bundle loads over the network, you wait for the actual UI, not a guessed number of seconds.
+
+The one hard-won lesson — covered in Part 1 but worth repeating because it dwarfs everything else — is to put `testID` on every interactive element from day one. Text selectors broke wholesale the moment we localised with CrowdIn. A `testID` is the only selector that survives a translation.
+
+## The build matrix
+
+The expensive part of mobile E2E isn't the test, it's getting a build to test against. EAS Workflows let me express the whole pipeline as jobs with dependencies, and the shape that emerged ran the suite across four build situations: iOS and Android, each either reused from cache or freshly built.
+
+The trick that made this affordable was loading JavaScript over the air. Each test job points the dev-client build at an [EAS Update](/blog/expo-ota-updates) channel via a deep link, so the native binary can be a cached artifact while the JS under test is the PR's bundle:
+
+```yaml
+env:
+  MAESTRO_DEEP_LINK_URL: 'exp+leather://expo-development-client/?url=https://u.expo.dev/<project>?channel-name=cicd'
+```
+
+Most PRs don't touch native code, so most runs reuse a cached build and only ship new JS — which is the whole reason CI stopped taking twenty minutes.
+
+## Smoke as a fast-fail gate
+
+Running the full suite four times over is slow, so I gated it. A small smoke flow runs first across all four build situations; only if smoke passes does the full suite run. In EAS Workflows that's just a `needs` edge:
+
+```yaml
+smoke_ios_cached:
+  name: iOS Smoke (cached)
+  type: maestro
+  params:
+    flow_path: maestro/flows/smoke-tests-ci.yaml
+
+maestro_ios_cached:
+  name: iOS Full Suite (cached)
+  needs: [smoke_ios_cached, get_ios_build]
+  type: maestro
+  params:
+    flow_path: maestro/flows/full-suite-ci.yaml
+```
+
+If the app can't even launch and reach the home screen, you find out in a minute instead of fifteen, and you don't burn a runner on the full journey for a broken build.
+
+## CI economics around the edges
+
+Two more things kept the pipeline cheap and quiet.
+
+First, a code-quality gate runs *before* any native build. There's no point spending a macOS runner on a build if the PR doesn't lint or typecheck, so a small job waits on the repo's existing checks (`lint-eslint`, `typecheck`, `lint-prettier`, `test-unit`) and the build validation only runs once they're green.
+
+Second, the path filters are scoped to what actually affects the mobile app. The build-validation workflow triggers on `apps/mobile/**` and the specific runtime packages it depends on — not on every change under `packages/**`. An edit to the browser extension, or to a package the app never imports, doesn't kick off a mobile build at all.
+
+## Two gotchas worth the post
+
+These two cost me real time and aren't in any getting-started guide.
+
+**`__DEV__` is `false` in an EAS Update bundle.** I gated a developer console behind `__DEV__`, which works locally and then vanishes in CI — because an over-the-air bundle is built in production mode even when it's loaded into a development client. The fix is to gate on an explicit environment variable instead, and to make sure the update step bakes it in:
+
+```yaml
+run_eas_update:
+  name: EAS Update
+  type: update
+  environment: development
+  params:
+    platform: all
+    channel: cicd
+```
+
+To make this debuggable, the dev console just prints what it sees, so a screenshot tells you whether the bundle has the env you expected:
+
+```tsx
+<Text variant="caption01">{`__DEV__: ${String(__DEV__)}`}</Text>
+<Text variant="caption01">{`NODE_ENV: ${process.env.EXPO_PUBLIC_NODE_ENV ?? 'undefined'}`}</Text>
+```
+
+**A `.gitignore` change can move your fingerprint.** EAS decides whether it can reuse a native build by hashing the inputs that affect the native runtime, and `.gitignore` is one of those inputs. Changing `android/` to `/android/` — semantically identical to a human — altered the hash and triggered fresh native builds on every PR until I reverted the slash. The fingerprint is exact; treat anything it reads as load-bearing.
+
+## Where it landed
+
+At its peak the suite covered the journeys that matter for a wallet: creation and restoration, the full settings tree, send and receive verification, network switching, and wallet removal — gated behind smoke, fanned across cached and fresh builds on both platforms, with most runs taking the fast over-the-air path. Maestro's YAML kept the tests themselves readable; the value was in the machine I built around it.

--- a/src/content/blog/maestro-sheets-ios-accessibility.md
+++ b/src/content/blog/maestro-sheets-ios-accessibility.md
@@ -1,0 +1,133 @@
+---
+title: "When Every Bottom Sheet Is Invisible: Maestro, iOS, and Accessibility"
+description: "Why our Maestro E2E tests passed on Android and failed on iOS — and how one accessibility prop on a bottom sheet broke (and then fixed) both testing and VoiceOver."
+pubDate: 2026-06-15
+tags: ["react-native", "mobile", "testing", "accessibility", "leather"]
+draft: true
+---
+
+Leather's mobile wallet is built out of bottom sheets. Send is a sheet. Receive is a sheet. Swap, ramp, add-account, add-wallet, the browser approver, the version guard — all sheets. The global sheet provider holds ten of them:
+
+```tsx
+sendSheetRef: SendSheetRef;
+receiveSheetRef: ReceiveSheetRef;
+swapSheetRef: SwapSheetRef;
+rampSheetRef: RampSheetRef;
+browserSheetRef: SheetRef;
+addAccountSheetRef: SheetRef;
+addWalletSheetRef: SheetRef;
+versionGuardSheetRef: SheetRef;
+descriptionSheetRef: DescriptionSheetRef;
+approverSheetRef: ApproverSheetRef;
+```
+
+It's a nice pattern for a wallet. Sheets keep you on the home screen, they animate in over your balances, and they compose well. Then I sat down to write end-to-end tests with [Maestro](https://maestro.mobile.dev/), and the entire model fell apart on one platform.
+
+## The symptom
+
+The tests passed on Android. On iOS, every single selector inside a sheet failed. Not "flaky" — failed, every time. Maestro couldn't find a button by `testID`, couldn't find a label by text, couldn't find anything. The sheet was right there on screen, visibly rendered, and the test runner was blind to its contents.
+
+That asymmetry is the clue. The same flow, the same `testID`s, the same app — green on Android, impossible on iOS.
+
+## The root cause
+
+Maestro drives iOS through XCUITest, and XCUITest reads the accessibility tree. So I started inspecting what iOS actually exposed for an open sheet, and the answer was: one element. The whole sheet showed up as a single opaque node labelled "Bottom Sheet". Nothing inside it existed as far as the accessibility tree was concerned.
+
+The cause is in [`@gorhom/bottom-sheet`](https://github.com/gorhom/react-native-bottom-sheet) (we're on `5.2.7`). Since v4.6.0 the library sets `accessible={true}` and `accessibilityRole="adjustable"` on the sheet container by default. On iOS, when a parent view is marked `accessible={true}`, UIKit treats it as a single accessibility element and **collapses all of its children into that one element**. VoiceOver — and therefore XCUITest, and therefore Maestro — sees the container and nothing beneath it.
+
+Android doesn't do this. TalkBack handles `accessible={true}` differently and still surfaces the children, which is why the exact same tests were green there. This wasn't a Maestro bug or a flake. It was the accessibility contract differing between the two platforms.
+
+## The fix
+
+One line, in our shared sheet wrapper:
+
+```tsx
+// packages/ui/src/components/sheet/sheet.native.tsx
+return (
+  <BottomSheetModal
+    accessible={false}
+    onChange={handleChange}
+    backdropComponent={SheetNativeBackdrop}
+    // ...
+  />
+);
+```
+
+Setting `accessible={false}` on the container tells iOS to stop grouping. The children become individual accessibility elements again, XCUITest can see them, and the `testID` selectors inside sheets start resolving.
+
+The part I didn't expect: this is also a real accessibility win. Before the change, a VoiceOver user on iOS couldn't navigate the individual controls inside any of our sheets either — the same collapse that hid elements from the test runner hid them from actual assistive tech. Fixing the tests fixed the app. That's the rare bug where the test harness was telling the truth about a user-facing defect.
+
+## The other scars
+
+The accessibility collapse was the headline, but sheets fought the test suite in smaller ways too.
+
+**Sheets have no back button.** You dismiss them with a downward swipe, so the tests have to do the same:
+
+```yaml
+# Close send sheet (no back button on sheets, swipe to dismiss)
+- swipe:
+    start: 50%, 15%
+    end: 50%, 85%
+- assertVisible:
+    id: 'homePrivacyButton'
+```
+
+**iOS concatenates labels.** Even with the accessibility fix, iOS renders a settings cell's title and caption as a single label. A network row that's a title ("Testnet4") plus a status caption ("Disabled") comes through as one string, so exact-text taps miss. The flows use regex instead:
+
+```yaml
+- tapOn: 'Testnet4.*Disabled'
+# ...and switching back, Mainnet is now the "Disabled" one
+- tapOn: 'Mainnet.*Disabled'
+```
+
+**Consecutive sheets race.** Open a sheet while the previous one is still animating out and `present()` silently no-ops. The approver sheet carries a manual guard for exactly this:
+
+```tsx
+// if the sheet is still somewhat open, wait a little bit before opening it up again
+if (animatedIndex.value !== sheetClosedIndex) {
+  setTimeout(() => {
+    ref.current?.present();
+  }, 500);
+} else {
+  ref.current?.present();
+}
+```
+
+That 500ms delay is a workaround in the app code, not the tests — but it's the same underlying problem. A sheet's "is it actually ready" state lives in a Reanimated value the test runner can't query, so timing has to be papered over on both sides.
+
+**Text input inside sheets is flaky on iOS.** This one is upstream. Maestro's `eraseText` and the `longPressOn` + "Select All" pattern are unreliable for sheet-hosted inputs on iOS, something the team left a note about in an older flow:
+
+```yaml
+# Doing this because iOS input is a bit flaky on maestro,
+# It's a known issue and they are on it.
+# https://maestro.mobile.dev/api-reference/commands/erasetext
+```
+
+## The pragmatic strategy
+
+Once you accept that sheets are hostile to E2E on iOS, the answer isn't to force one approach everywhere. It's to test the sheet behaviour where it's reliable and route around it where it isn't.
+
+So the suite splits by platform intent. Android keeps dedicated flows that exercise sheets directly — create a wallet through the add-wallet sheet, restore a wallet through the restore sheet:
+
+```yaml
+# maestro/flows/android/010-create-wallet-sheet.yaml
+- tapOn:
+    id: 'homeCreateWalletCard'
+- tapOn: 'Create new wallet'
+- tapOn:
+    id: 'walletCreationTapToReveal'
+- tapOn:
+    id: 'walletCreationBackedUpButton'
+- tapOn: 'Skip for now'
+- tapOn: 'Proceed'
+- assertVisible:
+    id: 'homeAccountCard-0'
+```
+
+The cross-platform full suite, which has to be reliable on both, sets up its wallet state through a developer console instead of driving the sheets — then goes on to test everything that lives outside or downstream of a sheet. Shared `runFlow` subflows keep the setup DRY across both worlds.
+
+The result: the flows that the accessibility bug had made impossible on iOS — wallet creation, settings navigation, send/receive verification, network switching, wallet removal — all run again, and the sheets that can be tested directly still are, on Android.
+
+## The takeaway
+
+Overusing bottom sheets is a code smell, and E2E testing is what surfaced it. The same property that made our sheets invisible to Maestro on iOS made them invisible to VoiceOver users on iOS. A UI pattern that's awkward to test is often a UI pattern that's awkward to use with assistive technology — they're frequently the same defect viewed from two angles. One `accessible={false}` fixed the test runner and the screen reader at once, which is the most satisfying kind of one-line change.

--- a/src/content/blog/mobile-ci-overengineering-fastlane-firebase.md
+++ b/src/content/blog/mobile-ci-overengineering-fastlane-firebase.md
@@ -1,0 +1,54 @@
+---
+title: "We Built the Whole Native CI Pipeline Before Realising We Didn't Need It"
+description: "How a mobile team reached for the Fastlane and Firebase playbook out of habit, then deleted most of it once EAS turned out to already do the job."
+pubDate: 2026-06-15
+tags: ["expo", "mobile", "ci", "leather"]
+draft: true
+---
+
+When a team starts a new mobile app, it tends to reach for the tooling it already knows. For us building [Leather](https://leather.io/)'s wallet, that meant the standard native CI playbook — the one the Flutter and bare-native world runs on. Fastlane to drive builds and signing, `match` to manage certificates, Firebase App Distribution to get beta builds to testers. It's a well-trodden path and it works.
+
+It also turned out to be mostly unnecessary. This is the story of building that pipeline carefully and then deleting most of it — and why that's a result, not a failure.
+
+## The pipeline we built first
+
+The first version was the "proper" one. The git history reads like a checklist of the native CI canon:
+
+- `ci: init fastlane`
+- `chore: add fastlane match`
+- `ci: initial fastlane firebase setup`
+- `feat: firebase notifications`
+- `fix: add fastlane deploy to firebase with version increment`
+- `chore: refactor fastlane to try and better share lanes, add slack hook`
+
+Each of those was real work. `match` meant setting up a certificates repository and getting signing identities synced across machines and CI. Firebase App Distribution meant wiring up the service, managing tester groups, and a Fastlane lane that built, incremented the version, and uploaded — with a Slack hook to announce it. None of it is hard exactly, but all of it is moving parts: secrets to store, services to keep authenticated, lanes to maintain, a whole second system sitting beside the app.
+
+We did it because that's what you do. If your mental model of mobile CI was formed on Flutter or bare React Native, Fastlane plus Firebase *is* the answer. You don't question it; you just set it up.
+
+## The realisation
+
+The thing that made us question it was already in the project: Expo's EAS.
+
+We'd adopted [EAS](https://expo.dev/eas) for builds, and once it was running properly, the overlap became impossible to ignore. The Fastlane-and-Firebase stack we'd carefully assembled was solving a list of problems EAS already solved:
+
+| What we'd built | What EAS already did |
+|---|---|
+| Fastlane lanes for cloud builds | EAS Build, both platforms |
+| `match` certificate management | EAS-managed signing credentials |
+| Firebase App Distribution for betas | EAS Build + internal distribution |
+| Manual version increments in a lane | Handled in the build pipeline |
+| Over-the-air updates (not even attempted) | EAS Update, out of the box |
+
+We had spent real time standing up infrastructure to do things the platform we were already paying for did natively — and in the case of OTA updates, it did things our hand-rolled pipeline never could.
+
+## The deletion
+
+So we ripped it out. Out went the Fastlane lanes, the `match` setup, the Firebase App Distribution wiring, the version-increment scripting, the Slack hook. The build, signing, and distribution story collapsed into EAS, and the maintenance surface shrank with it: fewer secrets in CI, fewer services to keep authenticated, fewer lanes that could rot.
+
+The most satisfying diffs are the ones that remove more than they add, and this was one of them — a pile of carefully-built scaffolding traded for configuration the platform already understood.
+
+## The lesson
+
+The mistake wasn't building the Fastlane pipeline. It was building it *first*, on reflex, before checking whether the stack we'd chosen already covered it. We imported a previous platform's defaults into a new one without asking if they still applied.
+
+The senior version of this instinct isn't "know Fastlane" or "know EAS." It's: when you adopt a platform, learn what it does for you *before* you build around it. The tooling you reach for out of habit is solving the problems of the last project, not necessarily this one. Pick the smallest thing that fits — and be willing to delete the rest when it turns out you reached too far.


### PR DESCRIPTION
## Summary
- Add four blog drafts (all `draft: true`) capturing mobile testing/CI work at Leather:
  - **maestro-sheets-ios-accessibility** — `@gorhom/bottom-sheet` defaults `accessible={true}`, which collapses the iOS accessibility tree so Maestro/XCUITest can't see anything inside a sheet; the one-line `accessible={false}` fix also restores VoiceOver.
  - **maestro-eas-e2e-deep-dive** — Part 2 to the fingerprinting post: Maestro's YAML model and the EAS Workflows build matrix (cached vs fresh, smoke-as-fast-fail-gate, OTA bundles).
  - **expo-at-leather** — showcase of the Expo/EAS stack; written so it can be offered to the Expo team, links out to existing posts.
  - **mobile-ci-overengineering-fastlane-firebase** — honest case study: built the full Fastlane + Firebase pipeline, then deleted most of it once EAS already covered it.
- Add a point-in-time dated note to `expo-cicd-fingerprinting.md` (kept `draft: false`); the EAS setup it describes has since changed.
- All technical specifics sourced verbatim from the live `leather-io/mono` PR diff; EAS-positive posts kept in past tense.

## Linked issue
Type: docs/content